### PR TITLE
Containerize microservices with Docker Compose

### DIFF
--- a/OrderService/.dockerignore
+++ b/OrderService/.dockerignore
@@ -1,0 +1,4 @@
+bin
+obj
+*.db
+*.db-*

--- a/OrderService/Dockerfile
+++ b/OrderService/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+COPY OrderService.csproj ./
+RUN dotnet restore
+
+COPY . ./
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:80
+RUN mkdir -p /data
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "OrderService.dll"]

--- a/OrderService/appsettings.Development.json
+++ b/OrderService/appsettings.Development.json
@@ -1,15 +1,15 @@
 {
-    "ConnectionStrings": {
-        "Default": "Data Source=orders.db"
-    },
-    "Services": {
-        "User": "http://localhost:5001",
-        "Product": "http://localhost:5003"
-    },
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
+  "ConnectionStrings": {
+    "Default": "Data Source=orders.db"
+  },
+  "Services": {
+    "User": "http://localhost:5001",
+    "Product": "http://localhost:5003"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
     }
+  }
 }

--- a/OrderService/appsettings.json
+++ b/OrderService/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "ConnectionStrings": {
+    "Default": "Data Source=orders.db"
+  },
+  "Services": {
+    "User": "http://user-service",
+    "Product": "http://product-service"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProductService/.dockerignore
+++ b/ProductService/.dockerignore
@@ -1,0 +1,3 @@
+bin
+obj
+*.db

--- a/ProductService/Dockerfile
+++ b/ProductService/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+COPY ProductService.csproj ./
+RUN dotnet restore
+
+COPY . ./
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:80
+RUN mkdir -p /data
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "ProductService.dll"]

--- a/ProductService/Program.cs
+++ b/ProductService/Program.cs
@@ -5,8 +5,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services
 builder.Services.AddControllers();
+
+var connectionString = builder.Configuration.GetConnectionString("Default") ?? "Data Source=products.db";
 builder.Services.AddDbContext<ProductContext>(options =>
-    options.UseSqlite("Data Source=products.db"));
+    options.UseSqlite(connectionString));
 
 var app = builder.Build();
 

--- a/ProductService/appsettings.Development.json
+++ b/ProductService/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Data Source=products.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/ProductService/appsettings.json
+++ b/ProductService/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Data Source=products.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/UserService/.dockerignore
+++ b/UserService/.dockerignore
@@ -1,0 +1,3 @@
+bin
+obj
+*.db

--- a/UserService/Dockerfile
+++ b/UserService/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+COPY UserService.csproj ./
+RUN dotnet restore
+
+COPY . ./
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:80
+RUN mkdir -p /data
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "UserService.dll"]

--- a/UserService/Program.cs
+++ b/UserService/Program.cs
@@ -5,8 +5,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services
 builder.Services.AddControllers();
+
+var connectionString = builder.Configuration.GetConnectionString("Default") ?? "Data Source=users.db";
 builder.Services.AddDbContext<UserContext>(options =>
-    options.UseSqlite("Data Source=users.db"));
+    options.UseSqlite(connectionString));
 
 var app = builder.Build();
 

--- a/UserService/appsettings.Development.json
+++ b/UserService/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Data Source=users.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/UserService/appsettings.json
+++ b/UserService/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Data Source=users.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.9"
+
+services:
+  user-service:
+    build:
+      context: ./UserService
+      dockerfile: Dockerfile
+    container_name: user-service
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__Default=Data Source=/data/users.db
+    volumes:
+      - user_data:/data
+    ports:
+      - "5001:80"
+
+  product-service:
+    build:
+      context: ./ProductService
+      dockerfile: Dockerfile
+    container_name: product-service
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__Default=Data Source=/data/products.db
+    volumes:
+      - product_data:/data
+    ports:
+      - "5003:80"
+
+  order-service:
+    build:
+      context: ./OrderService
+      dockerfile: Dockerfile
+    container_name: order-service
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ConnectionStrings__Default=Data Source=/data/orders.db
+      - Services__User=http://user-service
+      - Services__Product=http://product-service
+    depends_on:
+      - user-service
+      - product-service
+    volumes:
+      - order_data:/data
+    ports:
+      - "5005:80"
+
+volumes:
+  user_data:
+  product_data:
+  order_data:


### PR DESCRIPTION
## Summary
- add Dockerfiles and docker-compose configuration to run the three services together with volumes and service discovery
- update application settings to allow configurable SQLite paths for containerized deployments

## Testing
- ⚠️ `dotnet build MicroservicesDemo.sln` *(fails: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d81e6d142c832f9377aa8bda11cee2