### PR TITLE
Validate service base URLs from configuration

### DIFF
--- a/OrderService/External/ServiceEndpoints.cs
+++ b/OrderService/External/ServiceEndpoints.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace OrderService.External
 {
     public class ServiceEndpoints
     {
-        public string User { get; set; } = default!;
-        public string Product { get; set; } = default!;
+        [Required]
+        public Uri User { get; set; } = null!;
+
+        [Required]
+        public Uri Product { get; set; } = null!;
     }
 }


### PR DESCRIPTION
## Summary
- add options validation so downstream service base URLs must be provided by configuration
- update HTTP client registrations to consume Uri values supplied by the configuration binding

## Testing
- dotnet build MicroservicesDemo.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e2a78a88832f9876669e3d190792