### PR TITLE
Fix Docker builds for services referencing contracts

### DIFF
--- a/OrderService/Dockerfile
+++ b/OrderService/Dockerfile
@@ -2,11 +2,15 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
-COPY OrderService.csproj ./
-RUN dotnet restore
+# Copy project files first to leverage Docker layer caching
+COPY OrderService/OrderService.csproj OrderService/
+COPY Contracts/Contracts.csproj Contracts/
+RUN dotnet restore OrderService/OrderService.csproj
 
-COPY . ./
-RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+# Copy the remaining source code
+COPY OrderService/. OrderService/
+COPY Contracts/. Contracts/
+RUN dotnet publish OrderService/OrderService.csproj -c Release -o /app/publish /p:UseAppHost=false
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final

--- a/ProductService/Dockerfile
+++ b/ProductService/Dockerfile
@@ -2,11 +2,15 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
-COPY ProductService.csproj ./
-RUN dotnet restore
+# Copy project files first to leverage Docker layer caching
+COPY ProductService/ProductService.csproj ProductService/
+COPY Contracts/Contracts.csproj Contracts/
+RUN dotnet restore ProductService/ProductService.csproj
 
-COPY . ./
-RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+# Copy the remaining source code
+COPY ProductService/. ProductService/
+COPY Contracts/. Contracts/
+RUN dotnet publish ProductService/ProductService.csproj -c Release -o /app/publish /p:UseAppHost=false
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   rabbitmq:
     image: rabbitmq:3-management
@@ -23,8 +21,8 @@ services:
 
   product-service:
     build:
-      context: ./ProductService
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ProductService/Dockerfile
     container_name: product-service
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
@@ -42,8 +40,8 @@ services:
 
   order-service:
     build:
-      context: ./OrderService
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: OrderService/Dockerfile
     container_name: order-service
     environment:
       - ASPNETCORE_ENVIRONMENT=Production


### PR DESCRIPTION
## Summary
- update service Dockerfiles to copy the shared Contracts project so container builds succeed
- change docker-compose build contexts for contract-dependent services and drop the deprecated version field to silence warnings

## Testing
- not run (tooling unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8fb80edd8832f81a491dd3e6d2221