### PR TITLE
Refactor service startup code into extension classes

### DIFF
--- a/OrderService/Extensions/HttpClientPolicies.cs
+++ b/OrderService/Extensions/HttpClientPolicies.cs
@@ -1,0 +1,21 @@
+using Polly;
+using Polly.Extensions.Http;
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace OrderService.Extensions;
+
+public static class HttpClientPolicies
+{
+    public static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy() =>
+        HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .OrResult(message => message.StatusCode == HttpStatusCode.TooManyRequests)
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromMilliseconds(200 * Math.Pow(2, retryAttempt)));
+
+    public static IAsyncPolicy<HttpResponseMessage> CreateCircuitBreakerPolicy() =>
+        HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .CircuitBreakerAsync(handledEventsAllowedBeforeBreaking: 5, durationOfBreak: TimeSpan.FromSeconds(30));
+}

--- a/OrderService/Extensions/LoggingExtensions.cs
+++ b/OrderService/Extensions/LoggingExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Builder;
+using Serilog;
+using Serilog.Events;
+using System.IO;
+
+namespace OrderService.Extensions;
+
+public static class LoggingExtensions
+{
+    public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
+    {
+        builder.Host.UseSerilog((_, _, configuration) =>
+        {
+            var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+
+            configuration
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
+                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
+                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
+        });
+    }
+}

--- a/OrderService/Extensions/ServiceCollectionExtensions.cs
+++ b/OrderService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,104 @@
+using MassTransit;
+using System;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrderService.Data;
+using OrderService.External;
+using OrderService.Services;
+
+namespace OrderService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddOrderControllers(this IServiceCollection services)
+    {
+        services.AddControllers().AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        });
+
+        return services;
+    }
+
+    public static IServiceCollection AddOrderDatabase(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<OrderContext>(options =>
+            options.UseSqlite(configuration.GetConnectionString("Default")));
+
+        return services;
+    }
+
+    public static IServiceCollection AddServiceEndpoints(this IServiceCollection services, IConfiguration configuration)
+    {
+        services
+            .AddOptions<ServiceEndpoints>()
+            .Bind(configuration.GetRequiredSection("Services"))
+            .ValidateDataAnnotations()
+            .Validate(
+                endpoints => endpoints.User is { IsAbsoluteUri: true },
+                "The user service base URL must be an absolute URI.")
+            .Validate(
+                endpoints => endpoints.Product is { IsAbsoluteUri: true },
+                "The product service base URL must be an absolute URI.")
+            .ValidateOnStart();
+
+        return services;
+    }
+
+    public static IServiceCollection AddResilientHttpClients(this IServiceCollection services)
+    {
+        services.AddHttpClient<IUserServiceClient, UserServiceClient>((sp, client) =>
+            {
+                var endpoints = sp.GetRequiredService<IOptions<ServiceEndpoints>>().Value;
+                client.BaseAddress = endpoints.User;
+                client.Timeout = TimeSpan.FromSeconds(5);
+            })
+            .AddPolicyHandler(HttpClientPolicies.CreateRetryPolicy())
+            .AddPolicyHandler(HttpClientPolicies.CreateCircuitBreakerPolicy());
+
+        services.AddHttpClient<IProductServiceClient, ProductServiceClient>((sp, client) =>
+            {
+                var endpoints = sp.GetRequiredService<IOptions<ServiceEndpoints>>().Value;
+                client.BaseAddress = endpoints.Product;
+                client.Timeout = TimeSpan.FromSeconds(5);
+            })
+            .AddPolicyHandler(HttpClientPolicies.CreateRetryPolicy())
+            .AddPolicyHandler(HttpClientPolicies.CreateCircuitBreakerPolicy());
+
+        return services;
+    }
+
+    public static IServiceCollection AddOrderApplicationServices(this IServiceCollection services)
+    {
+        services.AddScoped<IOrderCreationService, OrderCreationService>();
+        return services;
+    }
+
+    public static IServiceCollection AddOrderMessaging(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMassTransit(busConfigurator =>
+        {
+            busConfigurator.SetKebabCaseEndpointNameFormatter();
+
+            busConfigurator.UsingRabbitMq((context, cfg) =>
+            {
+                var rabbitSection = configuration.GetSection("RabbitMq");
+                var host = rabbitSection.GetValue<string>("Host") ?? "rabbitmq";
+                var virtualHost = rabbitSection.GetValue<string>("VirtualHost") ?? "/";
+                var username = rabbitSection.GetValue<string>("Username") ?? "guest";
+                var password = rabbitSection.GetValue<string>("Password") ?? "guest";
+
+                cfg.Host(host, virtualHost, h =>
+                {
+                    h.Username(username);
+                    h.Password(password);
+                });
+            });
+        });
+
+        return services;
+    }
+}

--- a/OrderService/Extensions/WebApplicationExtensions.cs
+++ b/OrderService/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrderService.Extensions;
+
+public static class WebApplicationExtensions
+{
+    public static void ApplyMigrations<TContext>(this WebApplication app) where TContext : DbContext
+    {
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        context.Database.Migrate();
+    }
+}

--- a/OrderService/Program.cs
+++ b/OrderService/Program.cs
@@ -1,123 +1,19 @@
-using MassTransit;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrderService.Data;
-using OrderService.External;
-using OrderService.Services;
-using Polly;
-using Polly.Extensions.Http;
-using Serilog;
-using Serilog.Events;
-using System.Net;
+using OrderService.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-ConfigureLogging(builder);
+builder.ConfigureSerilogLogging();
 
-// Controllers & JSON
-builder.Services.AddControllers().AddJsonOptions(o =>
-{
-    o.JsonSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
-});
-
-// EF Core (SQLite)
-builder.Services.AddDbContext<OrderContext>(opt =>
-    opt.UseSqlite(builder.Configuration.GetConnectionString("Default")));
-
-// Bind endpoints from configuration (validated on startup)
-builder.Services
-    .AddOptions<ServiceEndpoints>()
-    .Bind(builder.Configuration.GetRequiredSection("Services"))
-    .ValidateDataAnnotations()
-    .Validate(
-        endpoints => endpoints.User is { IsAbsoluteUri: true },
-        "The user service base URL must be an absolute URI.")
-    .Validate(
-        endpoints => endpoints.Product is { IsAbsoluteUri: true },
-        "The product service base URL must be an absolute URI.")
-    .ValidateOnStart();
-
-// Resilience policies
-static IAsyncPolicy<HttpResponseMessage> RetryPolicy() =>
-    HttpPolicyExtensions
-        .HandleTransientHttpError()
-        .OrResult(msg => msg.StatusCode == HttpStatusCode.TooManyRequests)
-        .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromMilliseconds(200 * Math.Pow(2, retryAttempt)));
-
-static IAsyncPolicy<HttpResponseMessage> CircuitBreakerPolicy() =>
-    HttpPolicyExtensions
-        .HandleTransientHttpError()
-        .CircuitBreakerAsync(handledEventsAllowedBeforeBreaking: 5, durationOfBreak: TimeSpan.FromSeconds(30));
-
-// Typed clients with base addresses from config
-builder.Services.AddHttpClient<IUserServiceClient, UserServiceClient>((sp, http) =>
-{
-    var endpoints = sp.GetRequiredService<IOptions<ServiceEndpoints>>().Value;
-    http.BaseAddress = endpoints.User;
-    http.Timeout = TimeSpan.FromSeconds(5);
-})
-.AddPolicyHandler(RetryPolicy())
-.AddPolicyHandler(CircuitBreakerPolicy());
-
-builder.Services.AddHttpClient<IProductServiceClient, ProductServiceClient>((sp, http) =>
-{
-    var endpoints = sp.GetRequiredService<IOptions<ServiceEndpoints>>().Value;
-    http.BaseAddress = endpoints.Product;
-    http.Timeout = TimeSpan.FromSeconds(5);
-})
-.AddPolicyHandler(RetryPolicy())
-.AddPolicyHandler(CircuitBreakerPolicy());
-
-// App services
-builder.Services.AddScoped<IOrderCreationService, OrderCreationService>();
-
-builder.Services.AddMassTransit(busConfigurator =>
-{
-    busConfigurator.SetKebabCaseEndpointNameFormatter();
-
-    busConfigurator.UsingRabbitMq((context, cfg) =>
-    {
-        var rabbitSection = builder.Configuration.GetSection("RabbitMq");
-        var host = rabbitSection.GetValue<string>("Host") ?? "rabbitmq";
-        var virtualHost = rabbitSection.GetValue<string>("VirtualHost") ?? "/";
-        var username = rabbitSection.GetValue<string>("Username") ?? "guest";
-        var password = rabbitSection.GetValue<string>("Password") ?? "guest";
-
-        cfg.Host(host, virtualHost, h =>
-        {
-            h.Username(username);
-            h.Password(password);
-        });
-    });
-});
+builder.Services.AddOrderControllers();
+builder.Services.AddOrderDatabase(builder.Configuration);
+builder.Services.AddServiceEndpoints(builder.Configuration);
+builder.Services.AddResilientHttpClients();
+builder.Services.AddOrderApplicationServices();
+builder.Services.AddOrderMessaging(builder.Configuration);
 
 var app = builder.Build();
 
-using var scope = app.Services.CreateScope();
-var context = scope.ServiceProvider.GetRequiredService<OrderContext>();
-context.Database.Migrate();
-
 app.MapControllers();
+app.ApplyMigrations<OrderContext>();
 app.Run();
-
-static void ConfigureLogging(WebApplicationBuilder builder)
-{
-    builder.Host.UseSerilog((context, services, configuration) =>
-    {
-        var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
-
-        configuration
-            .Enrich.FromLogContext()
-            .WriteTo.Console()
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
-    });
-}

--- a/ProductService/Extensions/LoggingExtensions.cs
+++ b/ProductService/Extensions/LoggingExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Builder;
+using Serilog;
+using Serilog.Events;
+using System.IO;
+
+namespace ProductService.Extensions;
+
+public static class LoggingExtensions
+{
+    public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
+    {
+        builder.Host.UseSerilog((_, _, configuration) =>
+        {
+            var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+
+            configuration
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
+                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
+                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
+        });
+    }
+}

--- a/ProductService/Extensions/ServiceCollectionExtensions.cs
+++ b/ProductService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ProductService.Data;
+using ProductService.Messaging.Consumers;
+
+namespace ProductService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddProductDatabase(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("Default") ?? "Data Source=products.db";
+
+        services.AddDbContext<ProductContext>(options =>
+            options.UseSqlite(connectionString));
+
+        return services;
+    }
+
+    public static IServiceCollection AddProductMessaging(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMassTransit(busConfigurator =>
+        {
+            busConfigurator.AddConsumer<OrderCreatedConsumer>();
+            busConfigurator.SetKebabCaseEndpointNameFormatter();
+
+            busConfigurator.UsingRabbitMq((context, cfg) =>
+            {
+                var rabbitSection = configuration.GetSection("RabbitMq");
+                var host = rabbitSection.GetValue<string>("Host") ?? "rabbitmq";
+                var virtualHost = rabbitSection.GetValue<string>("VirtualHost") ?? "/";
+                var username = rabbitSection.GetValue<string>("Username") ?? "guest";
+                var password = rabbitSection.GetValue<string>("Password") ?? "guest";
+
+                cfg.Host(host, virtualHost, h =>
+                {
+                    h.Username(username);
+                    h.Password(password);
+                });
+
+                cfg.ConfigureEndpoints(context);
+            });
+        });
+
+        return services;
+    }
+}

--- a/ProductService/Extensions/WebApplicationExtensions.cs
+++ b/ProductService/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ProductService.Extensions;
+
+public static class WebApplicationExtensions
+{
+    public static void ApplyMigrations<TContext>(this WebApplication app) where TContext : DbContext
+    {
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        context.Database.Migrate();
+    }
+}

--- a/ProductService/Program.cs
+++ b/ProductService/Program.cs
@@ -1,72 +1,16 @@
-using MassTransit;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using ProductService.Data;
-using ProductService.Messaging.Consumers;
-using Serilog;
-using Serilog.Events;
+using ProductService.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-ConfigureLogging(builder);
+builder.ConfigureSerilogLogging();
 
-// Add services
 builder.Services.AddControllers();
-
-var connectionString = builder.Configuration.GetConnectionString("Default") ?? "Data Source=products.db";
-builder.Services.AddDbContext<ProductContext>(options =>
-    options.UseSqlite(connectionString));
-
-builder.Services.AddMassTransit(busConfigurator =>
-{
-    busConfigurator.AddConsumer<OrderCreatedConsumer>();
-    busConfigurator.SetKebabCaseEndpointNameFormatter();
-
-    busConfigurator.UsingRabbitMq((context, cfg) =>
-    {
-        var rabbitSection = builder.Configuration.GetSection("RabbitMq");
-        var host = rabbitSection.GetValue<string>("Host") ?? "rabbitmq";
-        var virtualHost = rabbitSection.GetValue<string>("VirtualHost") ?? "/";
-        var username = rabbitSection.GetValue<string>("Username") ?? "guest";
-        var password = rabbitSection.GetValue<string>("Password") ?? "guest";
-
-        cfg.Host(host, virtualHost, h =>
-        {
-            h.Username(username);
-            h.Password(password);
-        });
-
-        cfg.ConfigureEndpoints(context);
-    });
-});
+builder.Services.AddProductDatabase(builder.Configuration);
+builder.Services.AddProductMessaging(builder.Configuration);
 
 var app = builder.Build();
 
-using var scope = app.Services.CreateScope();
-var context = scope.ServiceProvider.GetRequiredService<ProductContext>();
-context.Database.Migrate();
-
-// Configure HTTP request pipeline
 app.MapControllers();
+app.ApplyMigrations<ProductContext>();
 app.Run();
-
-static void ConfigureLogging(WebApplicationBuilder builder)
-{
-    builder.Host.UseSerilog((context, services, configuration) =>
-    {
-        var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
-
-        configuration
-            .Enrich.FromLogContext()
-            .WriteTo.Console()
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
-    });
-}

--- a/UserService/Extensions/LoggingExtensions.cs
+++ b/UserService/Extensions/LoggingExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Builder;
+using Serilog;
+using Serilog.Events;
+using System.IO;
+
+namespace UserService.Extensions;
+
+public static class LoggingExtensions
+{
+    public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
+    {
+        builder.Host.UseSerilog((_, _, configuration) =>
+        {
+            var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+
+            configuration
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
+                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
+                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
+        });
+    }
+}

--- a/UserService/Extensions/ServiceCollectionExtensions.cs
+++ b/UserService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using UserService.Data;
+
+namespace UserService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddUserDatabase(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("Default") ?? "Data Source=users.db";
+
+        services.AddDbContext<UserContext>(options =>
+            options.UseSqlite(connectionString));
+
+        return services;
+    }
+
+    public static IServiceCollection AddUserMessaging(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMassTransit(busConfigurator =>
+        {
+            busConfigurator.SetKebabCaseEndpointNameFormatter();
+
+            busConfigurator.UsingRabbitMq((context, cfg) =>
+            {
+                var rabbitSection = configuration.GetSection("RabbitMq");
+                var host = rabbitSection.GetValue<string>("Host") ?? "rabbitmq";
+                var virtualHost = rabbitSection.GetValue<string>("VirtualHost") ?? "/";
+                var username = rabbitSection.GetValue<string>("Username") ?? "guest";
+                var password = rabbitSection.GetValue<string>("Password") ?? "guest";
+
+                cfg.Host(host, virtualHost, h =>
+                {
+                    h.Username(username);
+                    h.Password(password);
+                });
+
+                cfg.ConfigureEndpoints(context);
+            });
+        });
+
+        return services;
+    }
+}

--- a/UserService/Extensions/WebApplicationExtensions.cs
+++ b/UserService/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UserService.Extensions;
+
+public static class WebApplicationExtensions
+{
+    public static void ApplyMigrations<TContext>(this WebApplication app) where TContext : DbContext
+    {
+        using var scope = app.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        context.Database.Migrate();
+    }
+}

--- a/UserService/Program.cs
+++ b/UserService/Program.cs
@@ -1,70 +1,16 @@
-using MassTransit;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Serilog;
-using Serilog.Events;
 using UserService.Data;
+using UserService.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-ConfigureLogging(builder);
+builder.ConfigureSerilogLogging();
 
-// Add services
 builder.Services.AddControllers();
-
-var connectionString = builder.Configuration.GetConnectionString("Default") ?? "Data Source=users.db";
-builder.Services.AddDbContext<UserContext>(options =>
-    options.UseSqlite(connectionString));
-
-builder.Services.AddMassTransit(busConfigurator =>
-{
-    busConfigurator.SetKebabCaseEndpointNameFormatter();
-
-    busConfigurator.UsingRabbitMq((context, cfg) =>
-    {
-        var rabbitSection = builder.Configuration.GetSection("RabbitMq");
-        var host = rabbitSection.GetValue<string>("Host") ?? "rabbitmq";
-        var virtualHost = rabbitSection.GetValue<string>("VirtualHost") ?? "/";
-        var username = rabbitSection.GetValue<string>("Username") ?? "guest";
-        var password = rabbitSection.GetValue<string>("Password") ?? "guest";
-
-        cfg.Host(host, virtualHost, h =>
-        {
-            h.Username(username);
-            h.Password(password);
-        });
-
-        cfg.ConfigureEndpoints(context);
-    });
-});
+builder.Services.AddUserDatabase(builder.Configuration);
+builder.Services.AddUserMessaging(builder.Configuration);
 
 var app = builder.Build();
 
-using var scope = app.Services.CreateScope();
-var context = scope.ServiceProvider.GetRequiredService<UserContext>();
-context.Database.Migrate();
-
-// Configure pipeline
 app.MapControllers();
+app.ApplyMigrations<UserContext>();
 app.Run();
-
-static void ConfigureLogging(WebApplicationBuilder builder)
-{
-    builder.Host.UseSerilog((context, services, configuration) =>
-    {
-        var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
-
-        configuration
-            .Enrich.FromLogContext()
-            .WriteTo.Console()
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7))
-            .WriteTo.Logger(lc => lc
-                .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7));
-    });
-}


### PR DESCRIPTION
## Summary
- extract shared Serilog configuration into extension methods for each service
- move database, messaging, and migration helpers into dedicated extension classes to simplify Program.cs
- add Order service extensions for option binding and HTTP client resilience policies

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d905d8a81c832fbdf8daf9f6f829b5