### PR TITLE
Update Serilog log directory to Windows path

### DIFF
--- a/OrderService/Extensions/LoggingExtensions.cs
+++ b/OrderService/Extensions/LoggingExtensions.cs
@@ -11,7 +11,8 @@ public static class LoggingExtensions
     {
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+            var logDirectory = Path.Combine(@"C:\\Logs", "OrderService");
+            Directory.CreateDirectory(logDirectory);
 
             configuration
                 .Enrich.FromLogContext()

--- a/ProductService/Extensions/LoggingExtensions.cs
+++ b/ProductService/Extensions/LoggingExtensions.cs
@@ -11,7 +11,8 @@ public static class LoggingExtensions
     {
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+            var logDirectory = Path.Combine(@"C:\\Logs", "ProductService");
+            Directory.CreateDirectory(logDirectory);
 
             configuration
                 .Enrich.FromLogContext()

--- a/UserService/Extensions/LoggingExtensions.cs
+++ b/UserService/Extensions/LoggingExtensions.cs
@@ -11,7 +11,8 @@ public static class LoggingExtensions
     {
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "Logs");
+            var logDirectory = Path.Combine(@"C:\\Logs", "UserService");
+            Directory.CreateDirectory(logDirectory);
 
             configuration
                 .Enrich.FromLogContext()


### PR DESCRIPTION
## Summary
- update each service's Serilog configuration to write logs under `C:\Logs`
- ensure the target log directories are created before writing

## Testing
- `dotnet build MicroservicesDemo.sln` *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d90f0cb5e4832f85abb437ac479cc0