### PR TITLE
Fix OrderCreated event consumer logging

### DIFF
--- a/EventHubService/Messaging/Consumers/OrderCreatedEventConsumer.cs
+++ b/EventHubService/Messaging/Consumers/OrderCreatedEventConsumer.cs
@@ -15,6 +15,6 @@ public class OrderCreatedEventConsumer(IHubContext<NotificationHub> hubContext, 
     public async Task Consume(ConsumeContext<OrderCreatedEvent> context)
     {
         await _hubContext.Clients.All.SendAsync("OrderCreated", context.Message, context.CancellationToken);
-        _logger.LogInformation("Forwarded OrderCreatedEvent for Order {OrderId} to connected clients.", context.Message.OrderId);
+        _logger.LogInformation("Forwarded OrderCreatedEvent for Order {OrderId} to connected clients.", context.Message.Id);
     }
 }


### PR DESCRIPTION
## Summary
- fix the OrderCreated event consumer to log the correct property from the event payload

## Testing
- not run (dotnet CLI unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d915816560832fad02f98833d278a3