### PR TITLE
Fix logging configuration registration before configuring Serilog

### DIFF
--- a/EventHubService/Extensions/LoggingExtensions.cs
+++ b/EventHubService/Extensions/LoggingExtensions.cs
@@ -12,13 +12,13 @@ public static class LoggingExtensions
 {
     public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
     {
+        var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
+        Directory.CreateDirectory(logDirectory);
+
+        builder.Services.AddSingleton(new LogFileOptions(logDirectory));
+
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
-            Directory.CreateDirectory(logDirectory);
-
-            builder.Services.AddSingleton(new LogFileOptions(logDirectory));
-
             configuration
                 .Enrich.FromLogContext()
                 .WriteTo.Console()

--- a/OrderService/Extensions/LoggingExtensions.cs
+++ b/OrderService/Extensions/LoggingExtensions.cs
@@ -12,13 +12,13 @@ public static class LoggingExtensions
 {
     public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
     {
+        var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
+        Directory.CreateDirectory(logDirectory);
+
+        builder.Services.AddSingleton(new LogFileOptions(logDirectory));
+
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
-            Directory.CreateDirectory(logDirectory);
-
-            builder.Services.AddSingleton(new LogFileOptions(logDirectory));
-
             configuration
                 .Enrich.FromLogContext()
                 .WriteTo.Console()

--- a/ProductService/Extensions/LoggingExtensions.cs
+++ b/ProductService/Extensions/LoggingExtensions.cs
@@ -12,13 +12,13 @@ public static class LoggingExtensions
 {
     public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
     {
+        var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
+        Directory.CreateDirectory(logDirectory);
+
+        builder.Services.AddSingleton(new LogFileOptions(logDirectory));
+
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
-            Directory.CreateDirectory(logDirectory);
-
-            builder.Services.AddSingleton(new LogFileOptions(logDirectory));
-
             configuration
                 .Enrich.FromLogContext()
                 .WriteTo.Console()

--- a/UserService/Extensions/LoggingExtensions.cs
+++ b/UserService/Extensions/LoggingExtensions.cs
@@ -12,13 +12,13 @@ public static class LoggingExtensions
 {
     public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
     {
+        var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
+        Directory.CreateDirectory(logDirectory);
+
+        builder.Services.AddSingleton(new LogFileOptions(logDirectory));
+
         builder.Host.UseSerilog((_, _, configuration) =>
         {
-            var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
-            Directory.CreateDirectory(logDirectory);
-
-            builder.Services.AddSingleton(new LogFileOptions(logDirectory));
-
             configuration
                 .Enrich.FromLogContext()
                 .WriteTo.Console()


### PR DESCRIPTION
## Summary
- register `LogFileOptions` before the Serilog configuration runs so the service collection can be modified safely
- reuse the resolved log directory inside the Serilog setup for all services

## Testing
- `dotnet build MicroservicesDemo.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d91730f2e8832f9f5c1cd688e89267