### PR TITLE
Add RabbitMQ health checks to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.9"
+
 services:
   rabbitmq:
     image: rabbitmq:3-management
@@ -5,6 +7,11 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
 
   user-service:
     build:
@@ -36,7 +43,8 @@ services:
     ports:
       - "5003:80"
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
 
   order-service:
     build:
@@ -53,9 +61,12 @@ services:
       - RabbitMq__Username=guest
       - RabbitMq__Password=guest
     depends_on:
-      - user-service
-      - product-service
-      - rabbitmq
+      user-service:
+        condition: service_started
+      product-service:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
     volumes:
       - ./data/order-service:/data
     ports:
@@ -73,7 +84,8 @@ services:
       - RabbitMq__Username=guest
       - RabbitMq__Password=guest
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
     ports:
       - "5007:80"
 


### PR DESCRIPTION
## Summary
- declare the compose file version and add a health check for the RabbitMQ container
- gate the product, order, and event hub services on RabbitMQ becoming healthy before they start

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9190be67c832fbc3642b217ffcde9