### PR TITLE
Ensure log files exist for log endpoints

### DIFF
--- a/EventHubService/Extensions/LoggingExtensions.cs
+++ b/EventHubService/Extensions/LoggingExtensions.cs
@@ -14,6 +14,7 @@ public static class LoggingExtensions
     {
         var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
         Directory.CreateDirectory(logDirectory);
+        EnsureLogFilesExist(logDirectory);
 
         builder.Services.AddSingleton(new LogFileOptions(logDirectory));
 
@@ -32,5 +33,22 @@ public static class LoggingExtensions
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
                     .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
+    }
+
+    private static void EnsureLogFilesExist(string directory)
+    {
+        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        {
+            var filePath = Path.Combine(directory, fileName);
+            if (File.Exists(filePath))
+            {
+                continue;
+            }
+
+            using (File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // Ensure the file exists without locking it for other writers.
+            }
+        }
     }
 }

--- a/OrderService/Extensions/LoggingExtensions.cs
+++ b/OrderService/Extensions/LoggingExtensions.cs
@@ -14,6 +14,7 @@ public static class LoggingExtensions
     {
         var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
         Directory.CreateDirectory(logDirectory);
+        EnsureLogFilesExist(logDirectory);
 
         builder.Services.AddSingleton(new LogFileOptions(logDirectory));
 
@@ -32,5 +33,22 @@ public static class LoggingExtensions
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
                     .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
+    }
+
+    private static void EnsureLogFilesExist(string directory)
+    {
+        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        {
+            var filePath = Path.Combine(directory, fileName);
+            if (File.Exists(filePath))
+            {
+                continue;
+            }
+
+            using (File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // Ensure the file exists without locking it for other writers.
+            }
+        }
     }
 }

--- a/ProductService/Extensions/LoggingExtensions.cs
+++ b/ProductService/Extensions/LoggingExtensions.cs
@@ -14,6 +14,7 @@ public static class LoggingExtensions
     {
         var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
         Directory.CreateDirectory(logDirectory);
+        EnsureLogFilesExist(logDirectory);
 
         builder.Services.AddSingleton(new LogFileOptions(logDirectory));
 
@@ -32,5 +33,22 @@ public static class LoggingExtensions
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
                     .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
+    }
+
+    private static void EnsureLogFilesExist(string directory)
+    {
+        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        {
+            var filePath = Path.Combine(directory, fileName);
+            if (File.Exists(filePath))
+            {
+                continue;
+            }
+
+            using (File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // Ensure the file exists without locking it for other writers.
+            }
+        }
     }
 }

--- a/UserService/Extensions/LoggingExtensions.cs
+++ b/UserService/Extensions/LoggingExtensions.cs
@@ -14,6 +14,7 @@ public static class LoggingExtensions
     {
         var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
         Directory.CreateDirectory(logDirectory);
+        EnsureLogFilesExist(logDirectory);
 
         builder.Services.AddSingleton(new LogFileOptions(logDirectory));
 
@@ -32,5 +33,22 @@ public static class LoggingExtensions
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
                     .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
+    }
+
+    private static void EnsureLogFilesExist(string directory)
+    {
+        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        {
+            var filePath = Path.Combine(directory, fileName);
+            if (File.Exists(filePath))
+            {
+                continue;
+            }
+
+            using (File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // Ensure the file exists without locking it for other writers.
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- pre-create the info, warning, and error log files when configuring logging for each service
- avoid 404 responses from /api/logs/{level} when no entries have been written yet

## Testing
- dotnet build MicroservicesDemo.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d91f2cf56c832fb69e558a4e13cb41