### PR TITLE
Handle missing log files in services

### DIFF
--- a/EventHubService/Controllers/LogsController.cs
+++ b/EventHubService/Controllers/LogsController.cs
@@ -39,8 +39,8 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
         var filePath = Path.Combine(_logDirectory, fileName);
         if (!System.IO.File.Exists(filePath))
         {
-            _logger.LogInformation("Log file {File} not found.", filePath);
-            return NotFound();
+            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            return Content(string.Empty, "text/plain");
         }
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);

--- a/OrderService/Controller/LogsController.cs
+++ b/OrderService/Controller/LogsController.cs
@@ -39,8 +39,8 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
         var filePath = Path.Combine(_logDirectory, fileName);
         if (!System.IO.File.Exists(filePath))
         {
-            _logger.LogInformation("Log file {File} not found.", filePath);
-            return NotFound();
+            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            return Content(string.Empty, "text/plain");
         }
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);

--- a/ProductService/Controllers/LogsController.cs
+++ b/ProductService/Controllers/LogsController.cs
@@ -39,8 +39,8 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
         var filePath = Path.Combine(_logDirectory, fileName);
         if (!System.IO.File.Exists(filePath))
         {
-            _logger.LogInformation("Log file {File} not found.", filePath);
-            return NotFound();
+            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            return Content(string.Empty, "text/plain");
         }
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);

--- a/UserService/Controllers/LogsController.cs
+++ b/UserService/Controllers/LogsController.cs
@@ -39,8 +39,8 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
         var filePath = Path.Combine(_logDirectory, fileName);
         if (!System.IO.File.Exists(filePath))
         {
-            _logger.LogInformation("Log file {File} not found.", filePath);
-            return NotFound();
+            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            return Content(string.Empty, "text/plain");
         }
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);


### PR DESCRIPTION
## Summary
- return empty plain text responses from log endpoints when the backing file has not been created yet
- apply the same behavior across EventHub, Order, Product, and User services

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d91f84cc1c832faaae4d30a358ea13