### PR TITLE
Adjust frontend environment to use service-specific API URLs

### DIFF
--- a/frontend/src/app/services/log.service.ts
+++ b/frontend/src/app/services/log.service.ts
@@ -12,7 +12,7 @@ export interface LogEntry {
 
 @Injectable({ providedIn: 'root' })
 export class LogService {
-  private readonly baseUrl = `${environment.apiBaseUrl}/api/logs`;
+  private readonly baseUrl = `${environment.apiUrls.eventHub}/api/logs`;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/frontend/src/app/services/order.service.ts
+++ b/frontend/src/app/services/order.service.ts
@@ -19,7 +19,7 @@ export interface Order {
 
 @Injectable({ providedIn: 'root' })
 export class OrderService {
-  private readonly baseUrl = `${environment.apiBaseUrl}/api/orders`;
+  private readonly baseUrl = `${environment.apiUrls.order}/api/orders`;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/frontend/src/app/services/product.service.ts
+++ b/frontend/src/app/services/product.service.ts
@@ -14,7 +14,7 @@ export interface Product {
 
 @Injectable({ providedIn: 'root' })
 export class ProductService {
-  private readonly baseUrl = `${environment.apiBaseUrl}/api/products`;
+  private readonly baseUrl = `${environment.apiUrls.product}/api/products`;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -12,7 +12,7 @@ export interface User {
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
-  private readonly baseUrl = `${environment.apiBaseUrl}/api/users`;
+  private readonly baseUrl = `${environment.apiUrls.user}/api/users`;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,12 @@
+const backendBaseUrls = {
+  user: 'https://user-api.example.com',
+  product: 'https://product-api.example.com',
+  order: 'https://order-api.example.com',
+  eventHub: 'https://eventhub.example.com'
+} as const;
+
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://api.example.com',
-  signalRHubUrl: 'https://api.example.com/hubs/events'
+  apiUrls: backendBaseUrls,
+  signalRHubUrl: `${backendBaseUrls.eventHub}/hub/notifications`
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,12 @@
+const backendBaseUrls = {
+  user: 'http://localhost:5001',
+  product: 'http://localhost:5003',
+  order: 'http://localhost:5005',
+  eventHub: 'http://localhost:5007'
+} as const;
+
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:5000',
-  signalRHubUrl: 'http://localhost:5000/hubs/events'
+  apiUrls: backendBaseUrls,
+  signalRHubUrl: `${backendBaseUrls.eventHub}/hub/notifications`
 };


### PR DESCRIPTION
## Summary
- declare per-service backend URLs in the Angular environment configuration for development and production
- update API clients and SignalR configuration to reference the new service-specific endpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d92f74e194832fad0a6ab0cf69041a