### PR TITLE
Align navigation and card spacing

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -5,6 +5,8 @@
 
 .app-sidenav {
   width: 280px;
+  flex: 0 0 280px;
+  box-sizing: border-box;
   background: linear-gradient(160deg, #f8fafc 0%, #e0f2fe 55%, #dbeafe 100%);
   color: #0f172a;
   padding: 28px 16px;
@@ -74,6 +76,7 @@ a.mat-mdc-list-item {
   margin: 2px 8px;
   padding: 0 18px;
   border-radius: 12px;
+  width: calc(100% - 16px);
   color: rgba(15, 23, 42, 0.8);
   transition: background 150ms ease, color 150ms ease, box-shadow 150ms ease;
 }
@@ -87,6 +90,10 @@ a.mat-mdc-list-item mat-icon[matListItemIcon] {
 
 a.mat-mdc-list-item span[matListItemTitle] {
   font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  white-space: normal;
+  word-break: break-word;
 }
 
 a.mat-mdc-list-item:hover {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -48,10 +48,26 @@ mat-card {
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
   border: 1px solid rgba(148, 163, 184, 0.16);
   overflow: hidden;
+  --card-padding-x: 24px;
+  --card-padding-top: 24px;
+  --card-padding-bottom: 24px;
 }
 
 mat-card-title {
   font-weight: 600;
+  padding: var(--card-padding-top) var(--card-padding-x) 8px;
+}
+
+mat-card-subtitle {
+  padding: 0 var(--card-padding-x) 12px;
+}
+
+mat-card-content {
+  padding: 0 var(--card-padding-x) var(--card-padding-bottom);
+}
+
+mat-card-actions {
+  padding: 0 var(--card-padding-x) var(--card-padding-bottom);
 }
 
 .table-container {


### PR DESCRIPTION
## Summary
- prevent the sidenav from introducing a horizontal scrollbar by fixing its width and allowing long labels to wrap
- add consistent padding to card headings, bodies, and actions so table and form layouts stay aligned

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d93c2a3d94832f9be439a7f8c03e6f