### PR TITLE
Update log file rolling configuration across services

### DIFF
--- a/EventHubService/Controllers/LogsController.cs
+++ b/EventHubService/Controllers/LogsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHubService.Logging;
@@ -16,12 +17,12 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
     private static readonly IReadOnlyDictionary<string, string> LevelFileNames =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["info"] = "info.log",
-            ["information"] = "info.log",
-            ["warn"] = "warnings.log",
-            ["warning"] = "warnings.log",
-            ["error"] = "errors.log",
-            ["errors"] = "errors.log"
+            ["info"] = "info-.log",
+            ["information"] = "info-.log",
+            ["warn"] = "warnings-.log",
+            ["warning"] = "warnings-.log",
+            ["error"] = "errors-.log",
+            ["errors"] = "errors-.log"
         };
 
     private readonly string _logDirectory = options.Directory;
@@ -36,12 +37,20 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
             return BadRequest(new { error = "Unsupported log level. Use info, warning or error." });
         }
 
-        var filePath = Path.Combine(_logDirectory, fileName);
-        if (!System.IO.File.Exists(filePath))
+        var searchPattern = fileName.Insert(fileName.Length - ".log".Length, "*");
+        var matchingFiles = Directory.GetFiles(_logDirectory, searchPattern);
+
+        if (matchingFiles.Length == 0)
         {
-            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            _logger.LogInformation("No log files matching pattern {Pattern} found. Returning empty response.", searchPattern);
             return Content(string.Empty, "text/plain");
         }
+
+        var filePath = matchingFiles
+            .Select(path => new FileInfo(path))
+            .OrderByDescending(info => info.LastWriteTimeUtc)
+            .First()
+            .FullName;
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(stream);

--- a/EventHubService/Extensions/LoggingExtensions.cs
+++ b/EventHubService/Extensions/LoggingExtensions.cs
@@ -25,20 +25,21 @@ public static class LoggingExtensions
                 .WriteTo.Console()
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "info-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
+                    .WriteTo.File(Path.Combine(logDirectory, "errors-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
     }
 
     private static void EnsureLogFilesExist(string directory)
     {
-        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        foreach (var pattern in new[] { "info-.log", "warnings-.log", "errors-.log" })
         {
+            var fileName = pattern.Replace(".log", $"{DateTime.Now:yyyyMMdd}.log", StringComparison.Ordinal);
             var filePath = Path.Combine(directory, fileName);
             if (File.Exists(filePath))
             {

--- a/OrderService/Controller/LogsController.cs
+++ b/OrderService/Controller/LogsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -16,12 +17,12 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
     private static readonly IReadOnlyDictionary<string, string> LevelFileNames =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["info"] = "info.log",
-            ["information"] = "info.log",
-            ["warn"] = "warnings.log",
-            ["warning"] = "warnings.log",
-            ["error"] = "errors.log",
-            ["errors"] = "errors.log"
+            ["info"] = "info-.log",
+            ["information"] = "info-.log",
+            ["warn"] = "warnings-.log",
+            ["warning"] = "warnings-.log",
+            ["error"] = "errors-.log",
+            ["errors"] = "errors-.log"
         };
 
     private readonly string _logDirectory = options.Directory;
@@ -36,12 +37,20 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
             return BadRequest(new { error = "Unsupported log level. Use info, warning or error." });
         }
 
-        var filePath = Path.Combine(_logDirectory, fileName);
-        if (!System.IO.File.Exists(filePath))
+        var searchPattern = fileName.Insert(fileName.Length - ".log".Length, "*");
+        var matchingFiles = Directory.GetFiles(_logDirectory, searchPattern);
+
+        if (matchingFiles.Length == 0)
         {
-            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            _logger.LogInformation("No log files matching pattern {Pattern} found. Returning empty response.", searchPattern);
             return Content(string.Empty, "text/plain");
         }
+
+        var filePath = matchingFiles
+            .Select(path => new FileInfo(path))
+            .OrderByDescending(info => info.LastWriteTimeUtc)
+            .First()
+            .FullName;
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(stream);

--- a/OrderService/Extensions/LoggingExtensions.cs
+++ b/OrderService/Extensions/LoggingExtensions.cs
@@ -25,20 +25,21 @@ public static class LoggingExtensions
                 .WriteTo.Console()
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "info-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
+                    .WriteTo.File(Path.Combine(logDirectory, "errors-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
     }
 
     private static void EnsureLogFilesExist(string directory)
     {
-        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        foreach (var pattern in new[] { "info-.log", "warnings-.log", "errors-.log" })
         {
+            var fileName = pattern.Replace(".log", $"{DateTime.Now:yyyyMMdd}.log", StringComparison.Ordinal);
             var filePath = Path.Combine(directory, fileName);
             if (File.Exists(filePath))
             {

--- a/ProductService/Controllers/LogsController.cs
+++ b/ProductService/Controllers/LogsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -16,12 +17,12 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
     private static readonly IReadOnlyDictionary<string, string> LevelFileNames =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["info"] = "info.log",
-            ["information"] = "info.log",
-            ["warn"] = "warnings.log",
-            ["warning"] = "warnings.log",
-            ["error"] = "errors.log",
-            ["errors"] = "errors.log"
+            ["info"] = "info-.log",
+            ["information"] = "info-.log",
+            ["warn"] = "warnings-.log",
+            ["warning"] = "warnings-.log",
+            ["error"] = "errors-.log",
+            ["errors"] = "errors-.log"
         };
 
     private readonly string _logDirectory = options.Directory;
@@ -36,12 +37,20 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
             return BadRequest(new { error = "Unsupported log level. Use info, warning or error." });
         }
 
-        var filePath = Path.Combine(_logDirectory, fileName);
-        if (!System.IO.File.Exists(filePath))
+        var searchPattern = fileName.Insert(fileName.Length - ".log".Length, "*");
+        var matchingFiles = Directory.GetFiles(_logDirectory, searchPattern);
+
+        if (matchingFiles.Length == 0)
         {
-            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            _logger.LogInformation("No log files matching pattern {Pattern} found. Returning empty response.", searchPattern);
             return Content(string.Empty, "text/plain");
         }
+
+        var filePath = matchingFiles
+            .Select(path => new FileInfo(path))
+            .OrderByDescending(info => info.LastWriteTimeUtc)
+            .First()
+            .FullName;
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(stream);

--- a/ProductService/Extensions/LoggingExtensions.cs
+++ b/ProductService/Extensions/LoggingExtensions.cs
@@ -25,20 +25,21 @@ public static class LoggingExtensions
                 .WriteTo.Console()
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "info-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
+                    .WriteTo.File(Path.Combine(logDirectory, "errors-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
     }
 
     private static void EnsureLogFilesExist(string directory)
     {
-        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        foreach (var pattern in new[] { "info-.log", "warnings-.log", "errors-.log" })
         {
+            var fileName = pattern.Replace(".log", $"{DateTime.Now:yyyyMMdd}.log", StringComparison.Ordinal);
             var filePath = Path.Combine(directory, fileName);
             if (File.Exists(filePath))
             {

--- a/UserService/Controllers/LogsController.cs
+++ b/UserService/Controllers/LogsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -16,12 +17,12 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
     private static readonly IReadOnlyDictionary<string, string> LevelFileNames =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["info"] = "info.log",
-            ["information"] = "info.log",
-            ["warn"] = "warnings.log",
-            ["warning"] = "warnings.log",
-            ["error"] = "errors.log",
-            ["errors"] = "errors.log"
+            ["info"] = "info-.log",
+            ["information"] = "info-.log",
+            ["warn"] = "warnings-.log",
+            ["warning"] = "warnings-.log",
+            ["error"] = "errors-.log",
+            ["errors"] = "errors-.log"
         };
 
     private readonly string _logDirectory = options.Directory;
@@ -36,12 +37,20 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
             return BadRequest(new { error = "Unsupported log level. Use info, warning or error." });
         }
 
-        var filePath = Path.Combine(_logDirectory, fileName);
-        if (!System.IO.File.Exists(filePath))
+        var searchPattern = fileName.Insert(fileName.Length - ".log".Length, "*");
+        var matchingFiles = Directory.GetFiles(_logDirectory, searchPattern);
+
+        if (matchingFiles.Length == 0)
         {
-            _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
+            _logger.LogInformation("No log files matching pattern {Pattern} found. Returning empty response.", searchPattern);
             return Content(string.Empty, "text/plain");
         }
+
+        var filePath = matchingFiles
+            .Select(path => new FileInfo(path))
+            .OrderByDescending(info => info.LastWriteTimeUtc)
+            .First()
+            .FullName;
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var reader = new StreamReader(stream);

--- a/UserService/Extensions/LoggingExtensions.cs
+++ b/UserService/Extensions/LoggingExtensions.cs
@@ -25,20 +25,21 @@ public static class LoggingExtensions
                 .WriteTo.Console()
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
-                    .WriteTo.File(Path.Combine(logDirectory, "info.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "info-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
-                    .WriteTo.File(Path.Combine(logDirectory, "warnings.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
                 .WriteTo.Logger(lc => lc
                     .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
-                    .WriteTo.File(Path.Combine(logDirectory, "errors.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
+                    .WriteTo.File(Path.Combine(logDirectory, "errors-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
         });
     }
 
     private static void EnsureLogFilesExist(string directory)
     {
-        foreach (var fileName in new[] { "info.log", "warnings.log", "errors.log" })
+        foreach (var pattern in new[] { "info-.log", "warnings-.log", "errors-.log" })
         {
+            var fileName = pattern.Replace(".log", $"{DateTime.Now:yyyyMMdd}.log", StringComparison.Ordinal);
             var filePath = Path.Combine(directory, fileName);
             if (File.Exists(filePath))
             {


### PR DESCRIPTION
## Summary
- configure each service's Serilog sinks to use rolling file patterns compatible with daily rotation and existing retention
- ensure log controllers resolve the most recent file produced by the rolling pattern for each requested log level

## Testing
- `dotnet test MicroservicesDemo.sln` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d940448bc8832fb53006505948fb18