### PR TITLE
Return structured log entries from APIs

### DIFF
--- a/EventHubService/Controllers/LogsController.cs
+++ b/EventHubService/Controllers/LogsController.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHubService.Logging;
@@ -27,6 +29,21 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
     private readonly string _logDirectory = options.Directory;
     private readonly ILogger<LogsController> _logger = logger;
 
+    private static readonly Regex LogLineRegex = new(
+        "^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} [+-]\\d{2}:\\d{2}) \\\[(?<level>[A-Z]{3})\\\] (?<message>.*)$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly IReadOnlyDictionary<string, string> LevelDisplayNames =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["INF"] = "Information",
+            ["WRN"] = "Warning",
+            ["ERR"] = "Error",
+            ["FTL"] = "Fatal",
+            ["DBG"] = "Debug",
+            ["VRB"] = "Verbose"
+        };
+
     [HttpGet("{level}")]
     public async Task<IActionResult> GetLogs(string level, CancellationToken ct)
     {
@@ -40,7 +57,7 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
         if (!System.IO.File.Exists(filePath))
         {
             _logger.LogInformation("Log file {File} not found. Returning empty response.", filePath);
-            return Content(string.Empty, "text/plain");
+            return Ok(Array.Empty<LogEntry>());
         }
 
         await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -48,6 +65,59 @@ public class LogsController(LogFileOptions options, ILogger<LogsController> logg
         ct.ThrowIfCancellationRequested();
         var content = await reader.ReadToEndAsync();
 
-        return Content(content, "text/plain");
+        var entries = ParseLogEntries(content);
+
+        return Ok(entries);
     }
+
+    private static IReadOnlyList<LogEntry> ParseLogEntries(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return Array.Empty<LogEntry>();
+        }
+
+        var entries = new List<LogEntry>();
+        using var reader = new StringReader(content);
+        string? line;
+
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var match = LogLineRegex.Match(line);
+            if (!match.Success)
+            {
+                entries.Add(new LogEntry(null, null, line));
+                continue;
+            }
+
+            var timestampText = match.Groups["timestamp"].Value;
+            DateTimeOffset? timestamp = null;
+            if (DateTimeOffset.TryParse(
+                    timestampText,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var parsedTimestamp))
+            {
+                timestamp = parsedTimestamp;
+            }
+
+            var levelCode = match.Groups["level"].Value;
+            var levelDisplay = LevelDisplayNames.TryGetValue(levelCode, out var display)
+                ? display
+                : levelCode;
+
+            var message = match.Groups["message"].Value;
+
+            entries.Add(new LogEntry(timestamp, levelDisplay, message));
+        }
+
+        return entries;
+    }
+
+    private sealed record LogEntry(DateTimeOffset? Timestamp, string? Level, string Message);
 }


### PR DESCRIPTION
## Summary
- parse service log files into structured entries before returning them from the log endpoints
- map Serilog level abbreviations to human readable names so the UI can render them
- return an empty collection when a requested log file does not exist instead of raw text

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9424351e8832f98489f58585b4ffa