### PR TITLE
Ensure notification hub broadcasts integration events uniformly

### DIFF
--- a/EventHubService/Hubs/NotificationHub.cs
+++ b/EventHubService/Hubs/NotificationHub.cs
@@ -5,4 +5,5 @@ namespace EventHubService.Hubs;
 public class NotificationHub : Hub
 {
     public const string HubPath = "/hub/notifications";
+    public const string BroadcastEventMethod = "BroadcastEvent";
 }

--- a/EventHubService/Messaging/Consumers/OrderCreatedEventConsumer.cs
+++ b/EventHubService/Messaging/Consumers/OrderCreatedEventConsumer.cs
@@ -14,7 +14,12 @@ public class OrderCreatedEventConsumer(IHubContext<NotificationHub> hubContext, 
 
     public async Task Consume(ConsumeContext<OrderCreatedEvent> context)
     {
-        await _hubContext.Clients.All.SendAsync("OrderCreated", context.Message, context.CancellationToken);
+        await _hubContext.Clients.All.SendAsync(
+            NotificationHub.BroadcastEventMethod,
+            nameof(OrderCreatedEvent),
+            context.Message,
+            context.Message.CreatedAtUtc,
+            context.CancellationToken);
         _logger.LogInformation("Forwarded OrderCreatedEvent for Order {OrderId} to connected clients.", context.Message.Id);
     }
 }

--- a/EventHubService/Messaging/Consumers/OrderFailedEventConsumer.cs
+++ b/EventHubService/Messaging/Consumers/OrderFailedEventConsumer.cs
@@ -14,7 +14,12 @@ public class OrderFailedEventConsumer(IHubContext<NotificationHub> hubContext, I
 
     public async Task Consume(ConsumeContext<OrderFailedEvent> context)
     {
-        await _hubContext.Clients.All.SendAsync("OrderFailed", context.Message, context.CancellationToken);
+        await _hubContext.Clients.All.SendAsync(
+            NotificationHub.BroadcastEventMethod,
+            nameof(OrderFailedEvent),
+            context.Message,
+            context.Message.FailedAtUtc,
+            context.CancellationToken);
         _logger.LogInformation(
             "Forwarded OrderFailedEvent for Order {OrderId} to connected clients.",
             context.Message.OrderId);

--- a/EventHubService/Messaging/Consumers/StockDecreasedEventConsumer.cs
+++ b/EventHubService/Messaging/Consumers/StockDecreasedEventConsumer.cs
@@ -14,7 +14,12 @@ public class StockDecreasedEventConsumer(IHubContext<NotificationHub> hubContext
 
     public async Task Consume(ConsumeContext<StockDecreasedEvent> context)
     {
-        await _hubContext.Clients.All.SendAsync("StockDecreased", context.Message, context.CancellationToken);
+        await _hubContext.Clients.All.SendAsync(
+            NotificationHub.BroadcastEventMethod,
+            nameof(StockDecreasedEvent),
+            context.Message,
+            context.Message.ProcessedAtUtc,
+            context.CancellationToken);
         _logger.LogInformation(
             "Forwarded StockDecreasedEvent for Product {ProductId} to connected clients.",
             context.Message.ProductId);

--- a/EventHubService/Messaging/Consumers/UserCreatedEventConsumer.cs
+++ b/EventHubService/Messaging/Consumers/UserCreatedEventConsumer.cs
@@ -14,7 +14,12 @@ public class UserCreatedEventConsumer(IHubContext<NotificationHub> hubContext, I
 
     public async Task Consume(ConsumeContext<UserCreatedEvent> context)
     {
-        await _hubContext.Clients.All.SendAsync("UserCreated", context.Message, context.CancellationToken);
+        await _hubContext.Clients.All.SendAsync(
+            NotificationHub.BroadcastEventMethod,
+            nameof(UserCreatedEvent),
+            context.Message,
+            context.Message.CreatedAtUtc,
+            context.CancellationToken);
         _logger.LogInformation("Forwarded UserCreatedEvent for User {UserId} to connected clients.", context.Message.UserId);
     }
 }


### PR DESCRIPTION
## Summary
- add a BroadcastEvent hub method constant for downstream clients
- forward all consumed integration events through the BroadcastEvent method including event metadata

## Testing
- dotnet build EventHubService/EventHubService.csproj *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9524d756c832f946d09755425b934