### PR TITLE
Keep SignalR connection alive across navigation

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { EventService } from './services/event.service';
 
 interface NavItem {
   label: string;
@@ -11,7 +12,7 @@ interface NavItem {
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
+export class AppComponent implements OnInit, OnDestroy {
   title = 'Light Microservices';
   navItems: NavItem[] = [
     { label: 'Usuarios', icon: 'people', route: '/users' },
@@ -20,4 +21,14 @@ export class AppComponent {
     { label: 'Logs', icon: 'list_alt', route: '/logs' },
     { label: 'Eventos', icon: 'bolt', route: '/events' }
   ];
+
+  constructor(private readonly eventService: EventService) {}
+
+  ngOnInit(): void {
+    this.eventService.connect();
+  }
+
+  ngOnDestroy(): void {
+    this.eventService.disconnect();
+  }
 }

--- a/frontend/src/app/components/events-viewer/events-viewer.component.ts
+++ b/frontend/src/app/components/events-viewer/events-viewer.component.ts
@@ -14,14 +14,12 @@ export class EventsViewerComponent implements OnInit, OnDestroy {
   constructor(private readonly eventService: EventService) {}
 
   ngOnInit(): void {
-    this.eventService.connect();
     this.subscriptions.add(this.eventService.events$.subscribe(events => (this.events = events)));
     this.subscriptions.add(this.eventService.isConnected$.subscribe(state => (this.isConnected = state)));
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
-    this.eventService.disconnect();
   }
 
   clear(): void {


### PR DESCRIPTION
## Summary
- start the SignalR connection from the root app component so it remains active across navigation
- stop disconnecting the hub when the events viewer component is destroyed, while still cleaning up subscriptions

## Testing
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d95444c408832f83d0d3cb2a7d3e1b