### PR TITLE
Mostrar nombres de usuario y producto en la tabla de órdenes

### DIFF
--- a/frontend/src/app/components/orders/orders.component.html
+++ b/frontend/src/app/components/orders/orders.component.html
@@ -44,14 +44,14 @@
             <td mat-cell *matCellDef="let order">{{ order.id }}</td>
           </ng-container>
 
-          <ng-container matColumnDef="userId">
+          <ng-container matColumnDef="user">
             <th mat-header-cell *matHeaderCellDef>Usuario</th>
-            <td mat-cell *matCellDef="let order">{{ order.userId }}</td>
+            <td mat-cell *matCellDef="let order">{{ getUserName(order) }}</td>
           </ng-container>
 
-          <ng-container matColumnDef="productId">
+          <ng-container matColumnDef="product">
             <th mat-header-cell *matHeaderCellDef>Producto</th>
-            <td mat-cell *matCellDef="let order">{{ order.productId }}</td>
+            <td mat-cell *matCellDef="let order">{{ getProductName(order) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="quantity">

--- a/frontend/src/app/components/orders/orders.component.ts
+++ b/frontend/src/app/components/orders/orders.component.ts
@@ -14,7 +14,9 @@ export class OrdersComponent implements OnInit {
   orders: Order[] = [];
   users: User[] = [];
   products: Product[] = [];
-  displayedColumns = ['id', 'userId', 'productId', 'quantity', 'createdAtUtc'];
+  private userNameById = new Map<string, string>();
+  private productNameById = new Map<string, string>();
+  displayedColumns = ['id', 'user', 'product', 'quantity', 'createdAtUtc'];
   isLoadingOrders = false;
   isSubmitting = false;
 
@@ -39,11 +41,23 @@ export class OrdersComponent implements OnInit {
   }
 
   loadUsers(): void {
-    this.userService.getUsers().subscribe(users => (this.users = users));
+    this.userService.getUsers().subscribe(users => {
+      this.users = users;
+      this.userNameById.clear();
+      for (const user of users) {
+        this.userNameById.set(user.id, user.name);
+      }
+    });
   }
 
   loadProducts(): void {
-    this.productService.getProducts().subscribe(products => (this.products = products));
+    this.productService.getProducts().subscribe(products => {
+      this.products = products;
+      this.productNameById.clear();
+      for (const product of products) {
+        this.productNameById.set(product.id, product.name);
+      }
+    });
   }
 
   loadOrders(): void {
@@ -85,6 +99,14 @@ export class OrdersComponent implements OnInit {
         this.isSubmitting = false;
       }
     });
+  }
+
+  getUserName(order: Order): string {
+    return this.userNameById.get(order.userId) ?? order.userId;
+  }
+
+  getProductName(order: Order): string {
+    return this.productNameById.get(order.productId) ?? order.productId;
   }
 
 }


### PR DESCRIPTION
## Summary
- mostrar los nombres de usuarios y productos en la tabla de órdenes en lugar de los identificadores
- almacenar mapas locales para resolver los nombres a partir de los datos cargados

## Testing
- npm install (falló: 403 Forbidden al descargar dependencias)


------
https://chatgpt.com/codex/tasks/task_e_68d976a75e24832f95f13ce3e81f5a17