### PR TITLE
Add IAM service and secure microservices with JWT

### DIFF
--- a/EventHubService/Controllers/LogsController.cs
+++ b/EventHubService/Controllers/LogsController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventHubService.Logging;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -12,6 +13,7 @@ namespace EventHubService.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class LogsController(LogFileOptions options, ILogger<LogsController> logger) : ControllerBase
 {
     private static readonly IReadOnlyDictionary<string, string> LevelFileNames =

--- a/EventHubService/EventHubService.csproj
+++ b/EventHubService/EventHubService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageReference Include="MassTransit" Version="8.2.2" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />

--- a/EventHubService/Extensions/AuthenticationExtensions.cs
+++ b/EventHubService/Extensions/AuthenticationExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using EventHubService.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace EventHubService.Extensions;
+
+public static class AuthenticationExtensions
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+    {
+        var jwtOptions = configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>();
+        if (jwtOptions is null)
+        {
+            throw new InvalidOperationException("JWT configuration is missing");
+        }
+
+        services.AddSingleton(jwtOptions);
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SecretKey));
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.RequireHttpsMetadata = false;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    IssuerSigningKey = key,
+                    ClockSkew = TimeSpan.FromMinutes(1),
+                    RoleClaimType = "role"
+                };
+            });
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/EventHubService/Hubs/NotificationHub.cs
+++ b/EventHubService/Hubs/NotificationHub.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace EventHubService.Hubs;
 
+[Authorize]
 public class NotificationHub : Hub
 {
     public const string HubPath = "/hub/notifications";

--- a/EventHubService/Options/JwtOptions.cs
+++ b/EventHubService/Options/JwtOptions.cs
@@ -1,0 +1,10 @@
+namespace EventHubService.Options;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+}

--- a/EventHubService/Program.cs
+++ b/EventHubService/Program.cs
@@ -19,12 +19,15 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddEventHubServices(builder.Configuration);
+builder.Services.AddJwtAuthentication(builder.Configuration);
 
 var app = builder.Build();
 
 app.UseCors(allowAngularPolicy);
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
-app.MapHub<NotificationHub>(NotificationHub.HubPath);
+app.MapHub<NotificationHub>(NotificationHub.HubPath).RequireAuthorization();
 
 app.Run();

--- a/EventHubService/appsettings.Development.json
+++ b/EventHubService/appsettings.Development.json
@@ -1,4 +1,9 @@
 {
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/EventHubService/appsettings.json
+++ b/EventHubService/appsettings.json
@@ -11,5 +11,10 @@
     "Username": "guest",
     "Password": "guest"
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "AllowedHosts": "*"
 }

--- a/IAMService/Controllers/AuthController.cs
+++ b/IAMService/Controllers/AuthController.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using IAMService.Models;
+using IAMService.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IAMService.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController(IAuthService authService) : ControllerBase
+{
+    private readonly IAuthService _authService = authService;
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+    {
+        var response = await _authService.AuthenticateAsync(request, cancellationToken);
+        if (response is null)
+        {
+            return Unauthorized(new { error = "Credenciales inválidas" });
+        }
+
+        return Ok(response);
+    }
+}

--- a/IAMService/Dockerfile
+++ b/IAMService/Dockerfile
@@ -1,0 +1,19 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+COPY IAMService/IAMService.csproj IAMService/
+RUN dotnet restore IAMService/IAMService.csproj
+
+COPY IAMService/. IAMService/
+RUN dotnet publish IAMService/IAMService.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:80
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "IAMService.dll"]

--- a/IAMService/Extensions/JwtExtensions.cs
+++ b/IAMService/Extensions/JwtExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using IAMService.Options;
+
+namespace IAMService.Extensions;
+
+public static class JwtExtensions
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+    {
+        var jwtOptions = configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>();
+        if (jwtOptions is null)
+        {
+            throw new InvalidOperationException("JWT configuration is missing.");
+        }
+
+        services.AddSingleton(jwtOptions);
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SecretKey));
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.RequireHttpsMetadata = false;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidateLifetime = true,
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    IssuerSigningKey = key,
+                    ClockSkew = TimeSpan.FromMinutes(1),
+                    RoleClaimType = "role"
+                };
+            });
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/IAMService/Extensions/LoggingExtensions.cs
+++ b/IAMService/Extensions/LoggingExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Serilog.Events;
+using IAMService.Logging;
+
+namespace IAMService.Extensions;
+
+public static class LoggingExtensions
+{
+    public static void ConfigureSerilogLogging(this WebApplicationBuilder builder)
+    {
+        var logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
+        Directory.CreateDirectory(logDirectory);
+        EnsureLogFilesExist(logDirectory);
+
+        builder.Services.AddSingleton(new LogFileOptions(logDirectory));
+
+        builder.Host.UseSerilog((_, _, configuration) =>
+        {
+            configuration
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Information)
+                    .WriteTo.File(Path.Combine(logDirectory, "info-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level == LogEventLevel.Warning)
+                    .WriteTo.File(Path.Combine(logDirectory, "warnings-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true))
+                .WriteTo.Logger(lc => lc
+                    .Filter.ByIncludingOnly(e => e.Level >= LogEventLevel.Error)
+                    .WriteTo.File(Path.Combine(logDirectory, "errors-.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7, shared: true));
+        });
+    }
+
+    private static void EnsureLogFilesExist(string directory)
+    {
+        foreach (var pattern in new[] { "info-.log", "warnings-.log", "errors-.log" })
+        {
+            var fileName = pattern.Replace(".log", $"{DateTime.Now:yyyyMMdd}.log", StringComparison.Ordinal);
+            var filePath = Path.Combine(directory, fileName);
+            if (File.Exists(filePath))
+            {
+                continue;
+            }
+
+            using (File.Open(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // Ensure the file exists without locking it for other writers.
+            }
+        }
+    }
+}

--- a/IAMService/IAMService.csproj
+++ b/IAMService/IAMService.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/IAMService/Logging/LogFileOptions.cs
+++ b/IAMService/Logging/LogFileOptions.cs
@@ -1,0 +1,3 @@
+namespace IAMService.Logging;
+
+public sealed record LogFileOptions(string Directory);

--- a/IAMService/Models/AuthUser.cs
+++ b/IAMService/Models/AuthUser.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace IAMService.Models;
+
+public sealed class AuthUser
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string[] Roles { get; set; } = Array.Empty<string>();
+}

--- a/IAMService/Models/LoginRequest.cs
+++ b/IAMService/Models/LoginRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IAMService.Models;
+
+public sealed class LoginRequest
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+}

--- a/IAMService/Models/LoginResponse.cs
+++ b/IAMService/Models/LoginResponse.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace IAMService.Models;
+
+public sealed class LoginResponse
+{
+    public Guid UserId { get; init; }
+    public string Email { get; init; } = string.Empty;
+    public string[] Roles { get; init; } = Array.Empty<string>();
+    public string Token { get; init; } = string.Empty;
+    public DateTime ExpiresAtUtc { get; init; }
+}

--- a/IAMService/Options/AuthUsersOptions.cs
+++ b/IAMService/Options/AuthUsersOptions.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using IAMService.Models;
+
+namespace IAMService.Options;
+
+public sealed class AuthUsersOptions
+{
+    public const string SectionName = "AuthUsers";
+
+    public List<AuthUser> Users { get; set; } = new();
+}

--- a/IAMService/Options/JwtOptions.cs
+++ b/IAMService/Options/JwtOptions.cs
@@ -1,0 +1,11 @@
+namespace IAMService.Options;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+    public int AccessTokenMinutes { get; set; } = 60;
+}

--- a/IAMService/Program.cs
+++ b/IAMService/Program.cs
@@ -1,0 +1,38 @@
+using IAMService.Extensions;
+using IAMService.Options;
+using IAMService.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.ConfigureSerilogLogging();
+
+const string allowAngularPolicy = "AllowAngular";
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(allowAngularPolicy, policy =>
+    {
+        policy.WithOrigins("http://localhost:4200")
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
+
+var authUsersOptions = builder.Configuration.GetSection(AuthUsersOptions.SectionName).Get<AuthUsersOptions>() ?? new AuthUsersOptions();
+builder.Services.AddSingleton(authUsersOptions);
+
+builder.Services.AddJwtAuthentication(builder.Configuration);
+builder.Services.AddScoped<IAuthService, AuthService>();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.UseCors(allowAngularPolicy);
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/IAMService/Properties/launchSettings.json
+++ b/IAMService/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "IAMService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5009",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/IAMService/Services/AuthService.cs
+++ b/IAMService/Services/AuthService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using IAMService.Models;
+using IAMService.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IAMService.Services;
+
+public sealed class AuthService : IAuthService
+{
+    private readonly AuthUsersOptions _userOptions;
+    private readonly JwtOptions _jwtOptions;
+    private readonly ILogger<AuthService> _logger;
+    private readonly SigningCredentials _signingCredentials;
+
+    public AuthService(AuthUsersOptions userOptions, JwtOptions jwtOptions, ILogger<AuthService> logger)
+    {
+        _userOptions = userOptions;
+        _jwtOptions = jwtOptions;
+        _logger = logger;
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SecretKey));
+        _signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+    }
+
+    public Task<LoginResponse?> AuthenticateAsync(LoginRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = _userOptions.Users.FirstOrDefault(u => string.Equals(u.Email, request.Email, StringComparison.OrdinalIgnoreCase));
+        if (user is null)
+        {
+            _logger.LogWarning("Login attempt failed for {Email}: user not found.", request.Email);
+            return Task.FromResult<LoginResponse?>(null);
+        }
+
+        if (!string.Equals(user.Password, request.Password, StringComparison.Ordinal))
+        {
+            _logger.LogWarning("Login attempt failed for {Email}: invalid password.", request.Email);
+            return Task.FromResult<LoginResponse?>(null);
+        }
+
+        var expiresAtUtc = DateTime.UtcNow.AddMinutes(_jwtOptions.AccessTokenMinutes);
+        var claims = BuildClaims(user);
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtOptions.Issuer,
+            audience: _jwtOptions.Audience,
+            claims: claims,
+            notBefore: DateTime.UtcNow,
+            expires: expiresAtUtc,
+            signingCredentials: _signingCredentials);
+
+        var tokenValue = new JwtSecurityTokenHandler().WriteToken(token);
+
+        _logger.LogInformation("User {UserId} authenticated successfully.", user.Id);
+
+        return Task.FromResult<LoginResponse?>(new LoginResponse
+        {
+            UserId = user.Id,
+            Email = user.Email,
+            Roles = user.Roles,
+            Token = tokenValue,
+            ExpiresAtUtc = expiresAtUtc
+        });
+    }
+
+    private static IEnumerable<Claim> BuildClaims(AuthUser user)
+    {
+        yield return new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString());
+        yield return new Claim(JwtRegisteredClaimNames.Email, user.Email);
+        yield return new Claim(ClaimTypes.Email, user.Email);
+
+        foreach (var role in user.Roles)
+        {
+            yield return new Claim("role", role);
+        }
+    }
+}

--- a/IAMService/Services/IAuthService.cs
+++ b/IAMService/Services/IAuthService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using IAMService.Models;
+
+namespace IAMService.Services;
+
+public interface IAuthService
+{
+    Task<LoginResponse?> AuthenticateAsync(LoginRequest request, CancellationToken cancellationToken = default);
+}

--- a/IAMService/appsettings.Development.json
+++ b/IAMService/appsettings.Development.json
@@ -1,0 +1,24 @@
+{
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change",
+    "AccessTokenMinutes": 120
+  },
+  "AuthUsers": {
+    "Users": [
+      {
+        "Id": "11111111-1111-1111-1111-111111111111",
+        "Email": "admin@example.com",
+        "Password": "P@ssw0rd!",
+        "Roles": ["Admin", "User"]
+      },
+      {
+        "Id": "22222222-2222-2222-2222-222222222222",
+        "Email": "user@example.com",
+        "Password": "Pa$$word",
+        "Roles": ["User"]
+      }
+    ]
+  }
+}

--- a/IAMService/appsettings.json
+++ b/IAMService/appsettings.json
@@ -1,0 +1,31 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change",
+    "AccessTokenMinutes": 120
+  },
+  "AuthUsers": {
+    "Users": [
+      {
+        "Id": "11111111-1111-1111-1111-111111111111",
+        "Email": "admin@example.com",
+        "Password": "P@ssw0rd!",
+        "Roles": ["Admin", "User"]
+      },
+      {
+        "Id": "22222222-2222-2222-2222-222222222222",
+        "Email": "user@example.com",
+        "Password": "Pa$$word",
+        "Roles": ["User"]
+      }
+    ]
+  },
+  "AllowedHosts": "*"
+}

--- a/MicroservicesDemo.sln
+++ b/MicroservicesDemo.sln
@@ -1,68 +1,69 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserService", "UserService\UserService.csproj", "{5150CB66-C5B6-4935-AB18-08998AF270D2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserService", "UserService\\UserService.csproj", "{5150CB66-C5B6-4935-AB18-08998AF270D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProductService", "ProductService\ProductService.csproj", "{E80F3582-62B4-47FE-AE24-50B3F7B70C95}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProductService", "ProductService\\ProductService.csproj", "{E80F3582-62B4-47FE-AE24-50B3F7B70C95}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrderService", "OrderService\OrderService.csproj", "{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrderService", "OrderService\\OrderService.csproj", "{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contracts", "Contracts\Contracts.csproj", "{4C8B144D-8691-46DB-8AC6-F5D3F0E40745}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contracts", "Contracts\\Contracts.csproj", "{4C8B144D-8691-46DB-8AC6-F5D3F0E40745}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventHubService", "EventHubService\EventHubService.csproj", "{9BFBE72C-1979-4E48-9F4E-8BCFD344A199}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventHubService", "EventHubService\\EventHubService.csproj", "{9BFBE72C-1979-4E48-9F4E-8BCFD344A199}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IAMService", "IAMService\\IAMService.csproj", "{BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x64.Build.0 = Debug|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x86.Build.0 = Debug|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x64.ActiveCfg = Release|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x64.Build.0 = Release|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x86.ActiveCfg = Release|Any CPU
-		{5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x86.Build.0 = Release|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x64.Build.0 = Debug|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x86.Build.0 = Debug|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x64.ActiveCfg = Release|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x64.Build.0 = Release|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x86.ActiveCfg = Release|Any CPU
-		{E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x86.Build.0 = Release|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x64.Build.0 = Debug|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x86.Build.0 = Debug|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x64.ActiveCfg = Release|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x64.Build.0 = Release|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x86.ActiveCfg = Release|Any CPU
-		{37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x86.Build.0 = Release|Any CPU
-		{4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|x64.Build.0 = Debug|Any CPU
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Debug|x64 = Debug|x64
+                Debug|x86 = Debug|x86
+                Release|Any CPU = Release|Any CPU
+                Release|x64 = Release|x64
+                Release|x86 = Release|x86
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x64.Build.0 = Debug|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Debug|x86.Build.0 = Debug|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|Any CPU.Build.0 = Release|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x64.ActiveCfg = Release|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x64.Build.0 = Release|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x86.ActiveCfg = Release|Any CPU
+                {5150CB66-C5B6-4935-AB18-08998AF270D2}.Release|x86.Build.0 = Release|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x64.Build.0 = Debug|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Debug|x86.Build.0 = Debug|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x64.ActiveCfg = Release|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x64.Build.0 = Release|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x86.ActiveCfg = Release|Any CPU
+                {E80F3582-62B4-47FE-AE24-50B3F7B70C95}.Release|x86.Build.0 = Release|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x64.Build.0 = Debug|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Debug|x86.Build.0 = Debug|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x64.ActiveCfg = Release|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x64.Build.0 = Release|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x86.ActiveCfg = Release|Any CPU
+                {37AC2ABC-C052-49C3-8A74-6A2FD6B3071F}.Release|x86.Build.0 = Release|Any CPU
+                {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|x64.Build.0 = Debug|Any CPU
                 {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|x86.ActiveCfg = Debug|Any CPU
                 {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Debug|x86.Build.0 = Debug|Any CPU
                 {4C8B144D-8691-46DB-8AC6-F5D3F0E40745}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -83,8 +84,20 @@ Global
                 {9BFBE72C-1979-4E48-9F4E-8BCFD344A199}.Release|x64.Build.0 = Release|Any CPU
                 {9BFBE72C-1979-4E48-9F4E-8BCFD344A199}.Release|x86.ActiveCfg = Release|Any CPU
                 {9BFBE72C-1979-4E48-9F4E-8BCFD344A199}.Release|x86.Build.0 = Release|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Debug|x64.Build.0 = Debug|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Debug|x86.Build.0 = Debug|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Release|Any CPU.Build.0 = Release|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Release|x64.ActiveCfg = Release|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Release|x64.Build.0 = Release|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Release|x86.ActiveCfg = Release|Any CPU
+                {BAEDEE12-3851-4C82-BE96-5E71AB5FE1D4}.Release|x86.Build.0 = Release|Any CPU
         EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
 EndGlobal

--- a/OrderService/Controller/OrdersController.cs
+++ b/OrderService/Controller/OrdersController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OrderService.Models;
 using OrderService.Services;
@@ -7,6 +8,7 @@ namespace OrderService.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class OrdersController(IOrderCreationService service) : ControllerBase
 {
     private readonly IOrderCreationService _service = service;
@@ -19,6 +21,7 @@ public class OrdersController(IOrderCreationService service) : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Roles = "User,Admin")]
     public async Task<IActionResult> Create([FromBody] CreateOrderRequest req, CancellationToken ct)
     {
         var (ok, error, order) = await _service.CreateAsync(req.UserId, req.ProductId, req.Quantity, ct);

--- a/OrderService/Extensions/AuthenticationExtensions.cs
+++ b/OrderService/Extensions/AuthenticationExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using OrderService.Options;
+
+namespace OrderService.Extensions;
+
+public static class AuthenticationExtensions
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+    {
+        var jwtOptions = configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>();
+        if (jwtOptions is null)
+        {
+            throw new InvalidOperationException("JWT configuration is missing");
+        }
+
+        services.AddSingleton(jwtOptions);
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SecretKey));
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.RequireHttpsMetadata = false;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    IssuerSigningKey = key,
+                    ClockSkew = TimeSpan.FromMinutes(1),
+                    RoleClaimType = "role"
+                };
+            });
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/OrderService/Options/JwtOptions.cs
+++ b/OrderService/Options/JwtOptions.cs
@@ -1,0 +1,10 @@
+namespace OrderService.Options;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+}

--- a/OrderService/OrderService.csproj
+++ b/OrderService/OrderService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageReference Include="MassTransit" Version="8.2.2" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />

--- a/OrderService/Program.cs
+++ b/OrderService/Program.cs
@@ -22,10 +22,13 @@ builder.Services.AddOrderControllers();
 builder.Services.AddOrderDatabase(builder.Configuration);
 builder.Services.AddOrderApplicationServices();
 builder.Services.AddOrderMessaging(builder.Configuration);
+builder.Services.AddJwtAuthentication(builder.Configuration);
 
 var app = builder.Build();
 
 app.UseCors(allowAngularPolicy);
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 app.ApplyMigrations<OrderContext>();

--- a/OrderService/appsettings.Development.json
+++ b/OrderService/appsettings.Development.json
@@ -2,6 +2,11 @@
   "ConnectionStrings": {
     "Default": "Data Source=orders.db"
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "RabbitMq": {
     "Host": "localhost",
     "VirtualHost": "/",

--- a/OrderService/appsettings.json
+++ b/OrderService/appsettings.json
@@ -8,5 +8,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "AllowedHosts": "*"
 }

--- a/ProductService/Controllers/ProductsController.cs
+++ b/ProductService/Controllers/ProductsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ProductService.Data;
@@ -10,6 +11,7 @@ namespace ProductService.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class ProductsController(ProductContext context) : ControllerBase
 {
     private readonly ProductContext _context = context;
@@ -40,6 +42,7 @@ public class ProductsController(ProductContext context) : ControllerBase
 
     // POST: api/products
     [HttpPost]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<Product>> CreateProduct(Product product, CancellationToken ct)
     {
         if (product.Id == Guid.Empty)
@@ -54,6 +57,7 @@ public class ProductsController(ProductContext context) : ControllerBase
 
     // PUT: api/products/{id}
     [HttpPut("{id:guid}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> UpdateProduct(Guid id, Product updatedProduct, CancellationToken ct)
     {
         var product = await _context.Products.FirstOrDefaultAsync(p => p.Id == id, ct);
@@ -70,6 +74,7 @@ public class ProductsController(ProductContext context) : ControllerBase
 
     // DELETE: api/products/{id}
     [HttpDelete("{id:guid}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteProduct(Guid id, CancellationToken ct)
     {
         var product = await _context.Products.FirstOrDefaultAsync(p => p.Id == id, ct);

--- a/ProductService/Extensions/AuthenticationExtensions.cs
+++ b/ProductService/Extensions/AuthenticationExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using ProductService.Options;
+
+namespace ProductService.Extensions;
+
+public static class AuthenticationExtensions
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+    {
+        var jwtOptions = configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>();
+        if (jwtOptions is null)
+        {
+            throw new InvalidOperationException("JWT configuration is missing");
+        }
+
+        services.AddSingleton(jwtOptions);
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SecretKey));
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.RequireHttpsMetadata = false;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    IssuerSigningKey = key,
+                    ClockSkew = TimeSpan.FromMinutes(1),
+                    RoleClaimType = "role"
+                };
+            });
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/ProductService/Options/JwtOptions.cs
+++ b/ProductService/Options/JwtOptions.cs
@@ -1,0 +1,10 @@
+namespace ProductService.Options;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+}

--- a/ProductService/ProductService.csproj
+++ b/ProductService/ProductService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageReference Include="MassTransit" Version="8.2.2" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />

--- a/ProductService/Program.cs
+++ b/ProductService/Program.cs
@@ -19,12 +19,15 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddControllers();
+builder.Services.AddJwtAuthentication(builder.Configuration);
 builder.Services.AddProductDatabase(builder.Configuration);
 builder.Services.AddProductMessaging(builder.Configuration);
 
 var app = builder.Build();
 
 app.UseCors(allowAngularPolicy);
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 app.ApplyMigrations<ProductContext>();

--- a/ProductService/appsettings.Development.json
+++ b/ProductService/appsettings.Development.json
@@ -2,6 +2,11 @@
   "ConnectionStrings": {
     "Default": "Data Source=products.db"
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "RabbitMq": {
     "Host": "localhost",
     "VirtualHost": "/",

--- a/ProductService/appsettings.json
+++ b/ProductService/appsettings.json
@@ -8,5 +8,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "AllowedHosts": "*"
 }

--- a/UserService/Controllers/UsersController.cs
+++ b/UserService/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Contracts.Events;
 using MassTransit;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,7 @@ namespace UserService.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class UsersController(UserContext context, IPublishEndpoint publishEndpoint, ILogger<UsersController> logger) : ControllerBase
 {
     private readonly UserContext _context = context;
@@ -45,6 +47,7 @@ public class UsersController(UserContext context, IPublishEndpoint publishEndpoi
 
     // POST: api/users
     [HttpPost]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<User>> CreateUser(User user, CancellationToken ct)
     {
         if (user.Id == Guid.Empty)
@@ -69,6 +72,7 @@ public class UsersController(UserContext context, IPublishEndpoint publishEndpoi
 
     // PUT: api/users/{id}
     [HttpPut("{id:guid}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> UpdateUser(Guid id, User updatedUser, CancellationToken ct)
     {
         var existingUser = await _context.Users.FirstOrDefaultAsync(u => u.Id == id, ct);
@@ -86,6 +90,7 @@ public class UsersController(UserContext context, IPublishEndpoint publishEndpoi
 
     // DELETE: api/users/{id}
     [HttpDelete("{id:guid}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> DeleteUser(Guid id, CancellationToken ct)
     {
         var user = await _context.Users.FirstOrDefaultAsync(u => u.Id == id, ct);

--- a/UserService/Extensions/AuthenticationExtensions.cs
+++ b/UserService/Extensions/AuthenticationExtensions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using UserService.Options;
+
+namespace UserService.Extensions;
+
+public static class AuthenticationExtensions
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration)
+    {
+        var jwtOptions = configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>();
+        if (jwtOptions is null)
+        {
+            throw new InvalidOperationException("JWT configuration is missing");
+        }
+
+        services.AddSingleton(jwtOptions);
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.SecretKey));
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.RequireHttpsMetadata = false;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    IssuerSigningKey = key,
+                    ClockSkew = TimeSpan.FromMinutes(1),
+                    RoleClaimType = "role"
+                };
+            });
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/UserService/Options/JwtOptions.cs
+++ b/UserService/Options/JwtOptions.cs
@@ -1,0 +1,10 @@
+namespace UserService.Options;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+}

--- a/UserService/Program.cs
+++ b/UserService/Program.cs
@@ -19,12 +19,15 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddControllers();
+builder.Services.AddJwtAuthentication(builder.Configuration);
 builder.Services.AddUserDatabase(builder.Configuration);
 builder.Services.AddUserMessaging(builder.Configuration);
 
 var app = builder.Build();
 
 app.UseCors(allowAngularPolicy);
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 app.ApplyMigrations<UserContext>();

--- a/UserService/UserService.csproj
+++ b/UserService/UserService.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageReference Include="MassTransit" Version="8.2.2" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />

--- a/UserService/appsettings.Development.json
+++ b/UserService/appsettings.Development.json
@@ -2,6 +2,11 @@
   "ConnectionStrings": {
     "Default": "Data Source=users.db"
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/UserService/appsettings.json
+++ b/UserService/appsettings.json
@@ -14,5 +14,10 @@
     "Username": "guest",
     "Password": "guest"
   },
+  "Jwt": {
+    "Issuer": "LightMicroservices",
+    "Audience": "LightMicroservicesClients",
+    "SecretKey": "super-secret-development-key-please-change"
+  },
   "AllowedHosts": "*"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ConnectionStrings__Default=Data Source=/data/users.db
+      - Jwt__Issuer=LightMicroservices
+      - Jwt__Audience=LightMicroservicesClients
+      - Jwt__SecretKey=super-secret-development-key-please-change
     volumes:
       - ./data/user-service:/data
     ports:
@@ -38,6 +41,9 @@ services:
       - RabbitMq__VirtualHost=/
       - RabbitMq__Username=guest
       - RabbitMq__Password=guest
+      - Jwt__Issuer=LightMicroservices
+      - Jwt__Audience=LightMicroservicesClients
+      - Jwt__SecretKey=super-secret-development-key-please-change
     volumes:
       - ./data/product-service:/data
     ports:
@@ -60,6 +66,9 @@ services:
       - RabbitMq__VirtualHost=/
       - RabbitMq__Username=guest
       - RabbitMq__Password=guest
+      - Jwt__Issuer=LightMicroservices
+      - Jwt__Audience=LightMicroservicesClients
+      - Jwt__SecretKey=super-secret-development-key-please-change
     depends_on:
       user-service:
         condition: service_started
@@ -83,10 +92,27 @@ services:
       - RabbitMq__VirtualHost=/
       - RabbitMq__Username=guest
       - RabbitMq__Password=guest
+      - Jwt__Issuer=LightMicroservices
+      - Jwt__Audience=LightMicroservicesClients
+      - Jwt__SecretKey=super-secret-development-key-please-change
     depends_on:
       rabbitmq:
         condition: service_healthy
     ports:
       - "5007:80"
+
+  iam-service:
+    build:
+      context: .
+      dockerfile: IAMService/Dockerfile
+    container_name: iam-service
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - Jwt__Issuer=LightMicroservices
+      - Jwt__Audience=LightMicroservicesClients
+      - Jwt__SecretKey=super-secret-development-key-please-change
+      - Jwt__AccessTokenMinutes=120
+    ports:
+      - "5009:80"
 
 volumes: {}

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,18 +1,22 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { EventsViewerComponent } from './components/events-viewer/events-viewer.component';
+import { LoginComponent } from './components/login/login.component';
 import { LogsViewerComponent } from './components/logs-viewer/logs-viewer.component';
 import { OrdersComponent } from './components/orders/orders.component';
 import { ProductsComponent } from './components/products/products.component';
 import { UsersComponent } from './components/users/users.component';
+import { AuthGuard } from './services/auth.guard';
 
 const routes: Routes = [
+  { path: 'login', component: LoginComponent },
   { path: '', redirectTo: 'users', pathMatch: 'full' },
-  { path: 'users', component: UsersComponent },
-  { path: 'products', component: ProductsComponent },
-  { path: 'orders', component: OrdersComponent },
-  { path: 'logs', component: LogsViewerComponent },
-  { path: 'events', component: EventsViewerComponent }
+  { path: 'users', component: UsersComponent, canActivate: [AuthGuard] },
+  { path: 'products', component: ProductsComponent, canActivate: [AuthGuard] },
+  { path: 'orders', component: OrdersComponent, canActivate: [AuthGuard] },
+  { path: 'logs', component: LogsViewerComponent, canActivate: [AuthGuard] },
+  { path: 'events', component: EventsViewerComponent, canActivate: [AuthGuard] },
+  { path: '**', redirectTo: 'users' }
 ];
 
 @NgModule({

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container class="app-shell">
-  <mat-sidenav mode="side" opened class="app-sidenav">
+  <mat-sidenav *ngIf="isAuthenticated" mode="side" opened class="app-sidenav">
     <div class="sidenav-header">
       <div class="brand-icon">
         <mat-icon>blur_on</mat-icon>
@@ -25,7 +25,7 @@
     </mat-nav-list>
   </mat-sidenav>
 
-  <mat-sidenav-content>
+  <mat-sidenav-content [class.no-sidenav]="!isAuthenticated">
     <mat-toolbar color="primary" class="app-toolbar">
       <div class="toolbar-title">
         <mat-icon>dashboard</mat-icon>
@@ -34,8 +34,25 @@
           <span class="subtitle">Panel de microservicios</span>
         </div>
       </div>
+      <span class="spacer"></span>
+      <ng-container *ngIf="isAuthenticated; else loginAction">
+        <div class="auth-info">
+          <div class="user-details">
+            <span class="user-email">{{ userEmail }}</span>
+            <mat-chip-set *ngIf="userRoles.length > 0" aria-label="Roles del usuario" class="role-chips">
+              <mat-chip *ngFor="let role of userRoles" color="accent" selected>
+                {{ role }}
+              </mat-chip>
+            </mat-chip-set>
+          </div>
+          <button mat-stroked-button color="accent" (click)="logout()">Cerrar sesión</button>
+        </div>
+      </ng-container>
+      <ng-template #loginAction>
+        <button mat-flat-button color="accent" routerLink="/login">Iniciar sesión</button>
+      </ng-template>
     </mat-toolbar>
-    <main class="app-content">
+    <main class="app-content" [class.centered-content]="!isAuthenticated">
       <router-outlet></router-outlet>
     </main>
   </mat-sidenav-content>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -124,6 +124,34 @@ a.mat-mdc-list-item.active-link mat-icon {
   box-shadow: 0 12px 32px rgba(37, 99, 235, 0.2);
 }
 
+.spacer {
+  flex: 1 1 auto;
+}
+
+.auth-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.user-details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 4px;
+}
+
+.user-email {
+  font-weight: 600;
+}
+
+.role-chips {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 .toolbar-title {
   display: flex;
   align-items: center;
@@ -158,6 +186,21 @@ a.mat-mdc-list-item.active-link mat-icon {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
+}
+
+mat-sidenav-content.no-sidenav .app-content {
+  max-width: 720px;
+}
+
+.centered-content {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.read-only-banner {
+  background: rgba(59, 130, 246, 0.08);
+  color: #0f172a;
 }
 
 .page-container {

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { AuthService } from './services/auth.service';
 import { EventService } from './services/event.service';
 
 interface NavItem {
@@ -21,14 +24,41 @@ export class AppComponent implements OnInit, OnDestroy {
     { label: 'Logs', icon: 'list_alt', route: '/logs' },
     { label: 'Eventos', icon: 'bolt', route: '/events' }
   ];
+  isAuthenticated = false;
+  userEmail = '';
+  userRoles: string[] = [];
+  private readonly subscriptions = new Subscription();
 
-  constructor(private readonly eventService: EventService) {}
+  constructor(
+    private readonly eventService: EventService,
+    private readonly authService: AuthService,
+    private readonly router: Router
+  ) {}
 
   ngOnInit(): void {
-    this.eventService.connect();
+    const authSubscription = this.authService.authState$.subscribe(state => {
+      this.isAuthenticated = !!state;
+      this.userEmail = state?.email ?? '';
+      this.userRoles = state?.roles ?? [];
+
+      if (state) {
+        this.eventService.connect();
+      } else {
+        this.eventService.disconnect();
+        this.eventService.clearEvents();
+      }
+    });
+
+    this.subscriptions.add(authSubscription);
   }
 
   ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
     this.eventService.disconnect();
+  }
+
+  logout(): void {
+    this.authService.logout();
+    this.router.navigate(['/login']);
   }
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,16 +1,18 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { EventsViewerComponent } from './components/events-viewer/events-viewer.component';
+import { LoginComponent } from './components/login/login.component';
 import { LogsViewerComponent } from './components/logs-viewer/logs-viewer.component';
 import { OrdersComponent } from './components/orders/orders.component';
 import { ProductsComponent } from './components/products/products.component';
 import { UsersComponent } from './components/users/users.component';
+import { AuthInterceptor } from './services/auth.interceptor';
 
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSidenavModule } from '@angular/material/sidenav';
@@ -34,6 +36,7 @@ import { MatDividerModule } from '@angular/material/divider';
     UsersComponent,
     ProductsComponent,
     OrdersComponent,
+    LoginComponent,
     LogsViewerComponent,
     EventsViewerComponent
   ],
@@ -60,7 +63,13 @@ import { MatDividerModule } from '@angular/material/divider';
     MatChipsModule,
     MatDividerModule
   ],
-  providers: [],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true
+    }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -1,0 +1,28 @@
+<div class="login-container">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Inicia sesión</mat-card-title>
+      <mat-card-subtitle>Ingresa tus credenciales para continuar</mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <form [formGroup]="form" (ngSubmit)="submit()">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Email</mat-label>
+          <input matInput type="email" formControlName="email" autocomplete="email" />
+          <mat-error *ngIf="form.get('email')?.hasError('required')">El email es obligatorio.</mat-error>
+          <mat-error *ngIf="form.get('email')?.hasError('email')">Ingresa un email válido.</mat-error>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Contraseña</mat-label>
+          <input matInput type="password" formControlName="password" autocomplete="current-password" />
+          <mat-error *ngIf="form.get('password')?.hasError('required')">La contraseña es obligatoria.</mat-error>
+        </mat-form-field>
+
+        <button mat-flat-button color="primary" class="full-width" type="submit" [disabled]="isSubmitting">
+          {{ isSubmitting ? 'Iniciando sesión...' : 'Ingresar' }}
+        </button>
+      </form>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/frontend/src/app/components/login/login.component.scss
+++ b/frontend/src/app/components/login/login.component.scss
@@ -1,0 +1,20 @@
+.login-container {
+  min-height: calc(100vh - 128px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+
+  mat-card {
+    width: 100%;
+    max-width: 420px;
+  }
+}
+
+.full-width {
+  width: 100%;
+}
+
+mat-card-subtitle {
+  margin-bottom: 1.5rem;
+}

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss']
+})
+export class LoginComponent {
+  isSubmitting = false;
+  readonly form: FormGroup;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly authService: AuthService,
+    private readonly snackBar: MatSnackBar,
+    private readonly router: Router
+  ) {
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required]
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid || this.isSubmitting) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting = true;
+    const { email, password } = this.form.value;
+
+    this.authService
+      .login({ email: email ?? '', password: password ?? '' })
+      .subscribe({
+        next: () => {
+          this.snackBar.open('Inicio de sesión exitoso', undefined, { duration: 2500 });
+          this.router.navigate(['/users']);
+        },
+        error: () => {
+          this.snackBar.open('Credenciales inválidas. Inténtalo nuevamente.', undefined, { duration: 3500 });
+          this.isSubmitting = false;
+        },
+        complete: () => {
+          this.isSubmitting = false;
+        }
+      });
+  }
+}

--- a/frontend/src/app/components/products/products.component.html
+++ b/frontend/src/app/components/products/products.component.html
@@ -1,5 +1,5 @@
 <div class="page-container">
-  <mat-card>
+  <mat-card *ngIf="canManageProducts; else readOnlyInfo">
     <mat-card-title>{{ selectedProduct ? 'Editar producto' : 'Crear producto' }}</mat-card-title>
     <mat-card-content>
       <form [formGroup]="productForm" (ngSubmit)="submit()" class="form-grid">
@@ -31,6 +31,14 @@
     </mat-card-content>
   </mat-card>
 
+  <ng-template #readOnlyInfo>
+    <mat-card class="read-only-banner">
+      <mat-card-content>
+        Acceso de solo lectura. Debes ser administrador para crear, actualizar o eliminar productos.
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+
   <mat-card>
     <mat-card-title>Productos</mat-card-title>
     <mat-card-content>
@@ -56,7 +64,7 @@
             <td mat-cell *matCellDef="let product">{{ product.stock }}</td>
           </ng-container>
 
-          <ng-container matColumnDef="actions">
+          <ng-container *ngIf="canManageProducts" matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef>Acciones</th>
             <td mat-cell *matCellDef="let product">
               <button mat-button color="accent" (click)="selectProduct(product)">Editar</button>

--- a/frontend/src/app/components/users/users.component.html
+++ b/frontend/src/app/components/users/users.component.html
@@ -1,5 +1,5 @@
 <div class="page-container">
-  <mat-card>
+  <mat-card *ngIf="canManageUsers; else readOnlyInfo">
     <mat-card-title>{{ selectedUser ? 'Editar usuario' : 'Crear usuario' }}</mat-card-title>
     <mat-card-content>
       <form [formGroup]="userForm" (ngSubmit)="submit()" class="form-grid">
@@ -26,6 +26,14 @@
     </mat-card-content>
   </mat-card>
 
+  <ng-template #readOnlyInfo>
+    <mat-card class="read-only-banner">
+      <mat-card-content>
+        Acceso de solo lectura. Debes ser administrador para crear, actualizar o eliminar usuarios.
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+
   <mat-card>
     <mat-card-title>Usuarios</mat-card-title>
     <mat-card-content>
@@ -46,7 +54,7 @@
             <td mat-cell *matCellDef="let user">{{ user.email }}</td>
           </ng-container>
 
-          <ng-container matColumnDef="actions">
+          <ng-container *ngIf="canManageUsers" matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef>Acciones</th>
             <td mat-cell *matCellDef="let user">
               <button mat-button color="accent" (click)="selectUser(user)">Editar</button>

--- a/frontend/src/app/services/auth.guard.ts
+++ b/frontend/src/app/services/auth.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { Observable, map } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private readonly authService: AuthService, private readonly router: Router) {}
+
+  canActivate(): Observable<boolean | UrlTree> {
+    return this.authService.authState$.pipe(
+      map(state => {
+        if (state) {
+          return true;
+        }
+
+        return this.router.parseUrl('/login');
+      })
+    );
+  }
+}

--- a/frontend/src/app/services/auth.interceptor.ts
+++ b/frontend/src/app/services/auth.interceptor.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Observable, catchError, throwError } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly router: Router,
+    private readonly snackBar: MatSnackBar
+  ) {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const token = this.authService.token;
+    const isAuthRequest = req.url.includes('/api/auth/login');
+    if (!token) {
+      return next.handle(req).pipe(catchError(error => this.handleAuthError(error, isAuthRequest)));
+    }
+
+    const authenticatedRequest = req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    return next.handle(authenticatedRequest).pipe(catchError(error => this.handleAuthError(error, isAuthRequest)));
+  }
+
+  private handleAuthError(error: unknown, isAuthRequest: boolean): Observable<never> {
+    if (error instanceof HttpErrorResponse && (error.status === 401 || error.status === 403) && !isAuthRequest) {
+      this.authService.logout();
+      this.snackBar.open('Tu sesión ha expirado o no tienes permisos. Inicia sesión nuevamente.', 'Cerrar', {
+        duration: 3500
+      });
+      this.router.navigate(['/login']);
+    }
+
+    return throwError(() => error);
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, map, tap } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  userId: string;
+  email: string;
+  roles: string[];
+  token: string;
+  expiresAtUtc: string;
+}
+
+export interface AuthState {
+  userId: string;
+  email: string;
+  roles: string[];
+  token: string;
+  expiresAtUtc: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly storageKey = 'iam-auth-state';
+  private readonly stateSubject = new BehaviorSubject<AuthState | null>(this.loadInitialState());
+
+  readonly authState$ = this.stateSubject.asObservable();
+
+  constructor(private readonly http: HttpClient) {}
+
+  get token(): string | null {
+    return this.stateSubject.value?.token ?? null;
+  }
+
+  get roles(): string[] {
+    return this.stateSubject.value?.roles ?? [];
+  }
+
+  login(request: LoginRequest): Observable<AuthState> {
+    return this.http
+      .post<LoginResponse>(`${environment.apiUrls.iam}/api/auth/login`, request)
+      .pipe(
+        tap(response => this.setState({
+          userId: response.userId,
+          email: response.email,
+          roles: response.roles,
+          token: response.token,
+          expiresAtUtc: response.expiresAtUtc
+        })),
+        map(() => this.stateSubject.value as AuthState)
+      );
+  }
+
+  logout(): void {
+    this.setState(null);
+  }
+
+  hasRole(role: string): boolean {
+    return this.roles.includes(role);
+  }
+
+  private setState(state: AuthState | null): void {
+    this.stateSubject.next(state);
+
+    if (state) {
+      localStorage.setItem(this.storageKey, JSON.stringify(state));
+    } else {
+      localStorage.removeItem(this.storageKey);
+    }
+  }
+
+  private loadInitialState(): AuthState | null {
+    const raw = localStorage.getItem(this.storageKey);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as AuthState;
+      const expiration = new Date(parsed.expiresAtUtc);
+      if (Number.isNaN(expiration.getTime()) || expiration <= new Date()) {
+        localStorage.removeItem(this.storageKey);
+        return null;
+      }
+
+      return parsed;
+    } catch {
+      localStorage.removeItem(this.storageKey);
+      return null;
+    }
+  }
+}

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -2,7 +2,8 @@ const backendBaseUrls = {
   user: 'https://user-api.example.com',
   product: 'https://product-api.example.com',
   order: 'https://order-api.example.com',
-  eventHub: 'https://eventhub.example.com'
+  eventHub: 'https://eventhub.example.com',
+  iam: 'https://iam.example.com'
 } as const;
 
 export const environment = {

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -2,7 +2,8 @@ const backendBaseUrls = {
   user: 'http://localhost:5001',
   product: 'http://localhost:5003',
   order: 'http://localhost:5005',
-  eventHub: 'http://localhost:5007'
+  eventHub: 'http://localhost:5007',
+  iam: 'http://localhost:5009'
 } as const;
 
 export const environment = {


### PR DESCRIPTION
## Summary
- add a new IAM service with login endpoint, JWT issuance, and logging
- secure the EventHub, User, Product, and Order services with shared JWT authentication and authorization rules
- update the Angular client with login flow, token handling, route guards, and role-aware UI tweaks

## Testing
- dotnet build MicroservicesDemo.sln *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db97dddc8c832f80e44d7383933850