### PR TITLE
Configure local RabbitMQ for EventHubService development

### DIFF
--- a/EventHubService/appsettings.Development.json
+++ b/EventHubService/appsettings.Development.json
@@ -9,5 +9,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "RabbitMq": {
+    "Host": "localhost",
+    "VirtualHost": "/",
+    "Username": "guest",
+    "Password": "guest"
   }
 }


### PR DESCRIPTION
## Summary
- add a RabbitMQ configuration block to the development settings for EventHubService
- point the development RabbitMQ host to localhost while retaining default credentials for local debugging

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb7625ad8832fa0ef948ba6fe2fad