### PR TITLE
Configure JWT bearer for SignalR hubs

### DIFF
--- a/EventHubService/Extensions/AuthenticationExtensions.cs
+++ b/EventHubService/Extensions/AuthenticationExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using EventHubService.Hubs;
 using EventHubService.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
@@ -38,6 +39,22 @@ public static class AuthenticationExtensions
                     IssuerSigningKey = key,
                     ClockSkew = TimeSpan.FromMinutes(1),
                     RoleClaimType = "role"
+                };
+
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        var accessToken = context.Request.Query["access_token"];
+
+                        if (!string.IsNullOrEmpty(accessToken) &&
+                            context.HttpContext.Request.Path.StartsWithSegments(NotificationHub.HubPath))
+                        {
+                            context.Token = accessToken;
+                        }
+
+                        return System.Threading.Tasks.Task.CompletedTask;
+                    }
                 };
             });
 


### PR DESCRIPTION
## Summary
- add NotificationHub reference to the authentication extension
- configure JwtBearerEvents to read access tokens from SignalR connection queries

## Testing
- `dotnet build EventHubService/EventHubService.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbe5f51f0832f8871fb6052e1d843