### PR TITLE
Disable inbound JWT claim mapping across services

### DIFF
--- a/EventHubService/Extensions/AuthenticationExtensions.cs
+++ b/EventHubService/Extensions/AuthenticationExtensions.cs
@@ -28,6 +28,7 @@ public static class AuthenticationExtensions
             .AddJwtBearer(options =>
             {
                 options.RequireHttpsMetadata = false;
+                options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer = true,

--- a/IAMService/Extensions/JwtExtensions.cs
+++ b/IAMService/Extensions/JwtExtensions.cs
@@ -27,6 +27,7 @@ public static class JwtExtensions
             .AddJwtBearer(options =>
             {
                 options.RequireHttpsMetadata = false;
+                options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer = true,

--- a/OrderService/Extensions/AuthenticationExtensions.cs
+++ b/OrderService/Extensions/AuthenticationExtensions.cs
@@ -27,6 +27,7 @@ public static class AuthenticationExtensions
             .AddJwtBearer(options =>
             {
                 options.RequireHttpsMetadata = false;
+                options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer = true,

--- a/ProductService/Extensions/AuthenticationExtensions.cs
+++ b/ProductService/Extensions/AuthenticationExtensions.cs
@@ -27,6 +27,7 @@ public static class AuthenticationExtensions
             .AddJwtBearer(options =>
             {
                 options.RequireHttpsMetadata = false;
+                options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer = true,

--- a/UserService/Extensions/AuthenticationExtensions.cs
+++ b/UserService/Extensions/AuthenticationExtensions.cs
@@ -27,6 +27,7 @@ public static class AuthenticationExtensions
             .AddJwtBearer(options =>
             {
                 options.RequireHttpsMetadata = false;
+                options.MapInboundClaims = false;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuer = true,


### PR DESCRIPTION
## Summary
- disable inbound claim mapping before configuring JWT bearer validation in each service extension
- retain role claim type mapping to "role" so IAM-issued tokens authorize correctly

## Testing
- `dotnet build MicroservicesDemo.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbee4e214832fb6aa7cd3fee81a11